### PR TITLE
mu-plugin in playground to disable REST API auth

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -26,9 +26,11 @@ export class ApiClient {
 			url: `/index.php?rest_route=/wp/v2/posts`,
 			method: 'POST',
 			body: {
-				title: 'New Post from API Client - ' + (Math.random() + 1).toString(36).substring(7),
+				title:
+					'New Post from API Client - ' +
+					( Math.random() + 1 ).toString( 36 ).substring( 7 ),
 				content: 'This is a new post created via the API client.',
-				status: 'publish'
+				status: 'publish',
 			},
 		} );
 		console.log( response, response.json );

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -25,7 +25,11 @@ export class ApiClient {
 		const response = await this.playgroundClient.request( {
 			url: `/index.php?rest_route=/wp/v2/posts`,
 			method: 'POST',
-			body: {},
+			body: {
+				title: 'New Post from API Client - ' + (Math.random() + 1).toString(36).substring(7),
+				content: 'This is a new post created via the API client.',
+				status: 'publish'
+			},
 		} );
 		console.log( response, response.json );
 	}

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -21,6 +21,15 @@ export class ApiClient {
 		return this._siteUrl;
 	}
 
+	async createPost(): Promise< void > {
+		const response = await this.playgroundClient.request( {
+			url: `/index.php?rest_route=/wp/v2/posts`,
+			method: 'POST',
+			body: {},
+		} );
+		console.log( response, response.json );
+	}
+
 	async getPosts(): Promise< Post[] > {
 		const response = ( await this.get(
 			'/wp/v2/posts'

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -107,7 +107,7 @@ function steps(): StepDefinition[] {
 		{
 			step: 'writeFile',
 			path: '/wordpress/wp-content/mu-plugins/addFilter-1.php',
-			data: '<?php add_filter( "determine_current_user", function() { return 1; }, 99999 );',
+			data: '<?php add_filter( "rest_authentication_errors", "__return_true" ); add_filter( "determine_current_user", function() { return 1; }, 99999 );',
 		},
 	];
 }

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -106,7 +106,7 @@ function steps(): StepDefinition[] {
 		},
 		{
 			step: 'writeFile',
-			path: '/wordpress/wp-content/mu-plugins/addFilter-1.php',
+			path: '/wordpress/wp-content/mu-plugins/authenticate-rest-request.php',
 			data: authenticateRestRequest(),
 		},
 	];

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -100,6 +100,11 @@ function steps(): StepDefinition[] {
 			pluginName: 'Try WordPress',
 			pluginPath: '/wordpress/wp-content/plugins/try-wordpress',
 		},
+		{
+			step: 'writeFile',
+			path: 'wordpress/wp-content/mu-plugins/addFilter-1.php',
+			data: '<?php add_filter( "determine_current_user", function() { return 1; }, 99999 );',
+		},
 	];
 }
 

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -101,8 +101,12 @@ function steps(): StepDefinition[] {
 			pluginPath: '/wordpress/wp-content/plugins/try-wordpress',
 		},
 		{
+			step: 'mkdir',
+			path: '/wordpress/wp-content/mu-plugins',
+		},
+		{
 			step: 'writeFile',
-			path: 'wordpress/wp-content/mu-plugins/addFilter-1.php',
+			path: '/wordpress/wp-content/mu-plugins/addFilter-1.php',
 			data: '<?php add_filter( "determine_current_user", function() { return 1; }, 99999 );',
 		},
 	];

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -107,9 +107,16 @@ function steps(): StepDefinition[] {
 		{
 			step: 'writeFile',
 			path: '/wordpress/wp-content/mu-plugins/addFilter-1.php',
-			data: '<?php add_filter( "rest_authentication_errors", "__return_true" ); add_filter( "determine_current_user", function() { return 1; }, 99999 );',
+			data: authenticateRestRequest(),
 		},
 	];
+}
+
+function authenticateRestRequest(): string {
+	return `<?php
+add_filter( "rest_authentication_errors", "__return_true" );
+add_filter( "determine_current_user", function() { return 1; }, 99999 );
+`;
 }
 
 function deleteDefaultContent(): string {

--- a/src/ui/session/ViewSession.tsx
+++ b/src/ui/session/ViewSession.tsx
@@ -27,6 +27,15 @@ export function ViewSession() {
 					return <li key={ post.id }>{ post.title }</li>;
 				} ) }
 			</ul>
+			{ apiClient ? (
+				<button
+					onClick={ async () => {
+						await apiClient?.createPost();
+					} }
+				>
+					Create post
+				</button>
+			) : null }
 		</>
 	);
 }

--- a/src/ui/session/ViewSession.tsx
+++ b/src/ui/session/ViewSession.tsx
@@ -27,15 +27,6 @@ export function ViewSession() {
 					return <li key={ post.id }>{ post.title }</li>;
 				} ) }
 			</ul>
-			{ apiClient ? (
-				<button
-					onClick={ async () => {
-						await apiClient?.createPost();
-					} }
-				>
-					Create post
-				</button>
-			) : null }
 		</>
 	);
 }


### PR DESCRIPTION
This PR effectively solves our "how to auth" with REST API problem since we do this in playground specific to our browser extension and not in general with the backend plugin.

I ended up trying this "disabling auth" approach because with using password approach, that works with application passwords and not just regular user's password. And even with application passwords, there wasn't an easy way to communicate that to frontend once we create and set that up. Options exist for development purposes but not so much for prod, when folks are using this extension out in the wild.

I think this playground specific effect is quite a good option. Thoughts?