### PR TITLE
Call paste handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@wordpress/block-library": "^9.7.0",
 				"@wordpress/blocks": "^13.7.0",
 				"@wp-playground/client": "^0.9.39",
 				"react": "^18.3.1",
@@ -17,6 +18,7 @@
 				"@types/firefox-webext-browser": "^120.0.4",
 				"@types/react": "^18.3.5",
 				"@types/react-dom": "^18.3.0",
+				"@types/wordpress__block-library": "^2.6.3",
 				"@types/wordpress__blocks": "^12.5.14",
 				"@wordpress/scripts": "^29.0.0",
 				"concurrently": "^9.0.1",
@@ -89,7 +91,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
 			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/highlight": "^7.24.7",
@@ -163,7 +164,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
 			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.25.6",
@@ -294,7 +294,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
 			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
@@ -414,7 +413,6 @@
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
 			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -424,7 +422,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
 			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -473,7 +470,6 @@
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
 			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.24.7",
@@ -489,7 +485,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
 			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.25.6"
@@ -2033,7 +2028,6 @@
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
 			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
@@ -2048,7 +2042,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
 			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
@@ -2067,7 +2060,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
 			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.24.8",
@@ -2168,7 +2160,6 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
 			"integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.7",
@@ -2188,14 +2179,12 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -2208,7 +2197,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2218,7 +2206,6 @@
 			"version": "11.13.1",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
 			"integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0",
@@ -2232,7 +2219,6 @@
 			"version": "11.13.0",
 			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.0.tgz",
 			"integrity": "sha512-BUk99ylT+YHl+W/HN7nv1RCTkDYmKKqa1qbvM/qLSQEg61gipuBF5Hptk/2/ERmX2DCv0ccuFGhz9i0KSZOqPg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/babel-plugin": "^11.12.0",
@@ -2246,14 +2232,12 @@
 			"version": "0.9.2",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
 			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/is-prop-valid": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
 			"integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0"
@@ -2263,14 +2247,12 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
 			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/react": {
 			"version": "11.13.3",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
 			"integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
@@ -2295,7 +2277,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.1.tgz",
 			"integrity": "sha512-dEPNKzBPU+vFPGa+z3axPRn8XVDetYORmDC0wAiej+TNcOZE70ZMJa0X7JdeoM6q/nWTMZeLpN/fTnD9o8MQBA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/hash": "^0.9.2",
@@ -2309,14 +2290,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
 			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/styled": {
 			"version": "11.13.0",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
 			"integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
@@ -2340,14 +2319,12 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
 			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
 			"integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": ">=16.8.0"
@@ -2357,14 +2334,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
 			"integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@emotion/weak-memoize": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
 			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@es-joy/jsdoccomment": {
@@ -2556,7 +2531,6 @@
 			"version": "1.6.7",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
 			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.7"
@@ -2566,7 +2540,6 @@
 			"version": "1.6.10",
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
 			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.6.0",
@@ -2577,7 +2550,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
 			"integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.0.0"
@@ -2591,7 +2563,6 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
 			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@fluent/syntax": {
@@ -3492,7 +3463,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
 			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -3507,7 +3477,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3517,7 +3486,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3538,14 +3506,12 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
 			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -4430,6 +4396,32 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@preact/signals": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.0.tgz",
+			"integrity": "sha512-EOMeg42SlLS72dhoq6Vjq08havnLseWmPQ8A0YsgIAqMgWgx7V1a39+Pxo6i7SY5NwJtH4849JogFq3M67AzWg==",
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.8.0.tgz",
+			"integrity": "sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/@puppeteer/browsers": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
@@ -4464,6 +4456,417 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+			"integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+			"integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+			"integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+			"integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-context": "1.0.1",
+				"@radix-ui/react-dismissable-layer": "1.0.5",
+				"@radix-ui/react-focus-guards": "1.0.1",
+				"@radix-ui/react-focus-scope": "1.0.4",
+				"@radix-ui/react-id": "1.0.1",
+				"@radix-ui/react-portal": "1.0.4",
+				"@radix-ui/react-presence": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-slot": "1.0.2",
+				"@radix-ui/react-use-controllable-state": "1.0.1",
+				"aria-hidden": "^1.1.1",
+				"react-remove-scroll": "2.5.5"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+			"integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-use-callback-ref": "1.0.1",
+				"@radix-ui/react-use-escape-keydown": "1.0.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+			"integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+			"integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-use-callback-ref": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+			"integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-layout-effect": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+			"integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-primitive": "1.0.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+			"integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-use-layout-effect": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+			"integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "1.0.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+			"integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+			"integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+			"integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-escape-keydown": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+			"integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "1.0.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+			"integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-spring/animated": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.4.tgz",
+			"integrity": "sha512-7As+8Pty2QlemJ9O5ecsuPKjmO0NKvmVkRR1n6mEotFgWar8FKuQt2xgxz3RTgxcccghpx1YdS1FCdElQNexmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/core": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.4.tgz",
+			"integrity": "sha512-GzjA44niEJBFUe9jN3zubRDDDP2E4tBlhNlSIkTChiNf9p4ZQlgXBg50qbXfSXHQPHak/ExYxwhipKVsQ/sUTw==",
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.4",
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-spring/donate"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/rafz": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.4.tgz",
+			"integrity": "sha512-mqDI6rW0Ca8IdryOMiXRhMtVGiEGLIO89vIOyFQXRIwwIMX30HLya24g9z4olDvFyeDW3+kibiKwtZnA4xhldA==",
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/shared": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.4.tgz",
+			"integrity": "sha512-bEPI7cQp94dOtCFSEYpxvLxj0+xQfB5r9Ru1h8OMycsIq7zFZon1G0sHrBLaLQIWeMCllc4tVDYRTLIRv70C8w==",
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/rafz": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/types": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.4.tgz",
+			"integrity": "sha512-iQVztO09ZVfsletMiY+DpT/JRiBntdsdJ4uqk3UJFhrhS8mIC9ZOZbmfGSRs/kdbNPQkVyzucceDicQ/3Mlj9g==",
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/web": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.4.tgz",
+			"integrity": "sha512-UMvCZp7I5HCVIleSa4BwbNxynqvj+mJjG2m20VO2yPoi2pnCYANy58flvz9v/YcXTAvsmL655FV3pm5fbr6akA==",
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.4",
+				"@react-spring/core": "~9.7.4",
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@remix-run/router": {
@@ -5239,7 +5642,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/har-format": {
@@ -5253,7 +5655,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
 			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/http-cache-semantics": {
@@ -5399,7 +5800,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
 			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/prop-types": {
@@ -5498,6 +5898,15 @@
 				"@types/send": "*"
 			}
 		},
+		"node_modules/@types/simple-peer": {
+			"version": "9.11.8",
+			"resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.8.tgz",
+			"integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/sockjs": {
 			"version": "0.3.36",
 			"resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
@@ -5592,6 +6001,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/@types/wordpress__block-library": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-library/-/wordpress__block-library-2.6.3.tgz",
+			"integrity": "sha512-Rr5iO7k1j6B0d5N6ZSZjspE/Ko9fBrfTsytw8v2VgR4kGs8Z3KM/lg0Nb5UNqTBjbdv7eIvsuNvQcTzlc+IlJA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/wordpress__blocks": {
 			"version": "12.5.14",
@@ -6169,14 +6585,12 @@
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
 			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@use-gesture/react": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
 			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@use-gesture/core": "10.3.1"
@@ -6408,6 +6822,21 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/api-fetch": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.7.0.tgz",
+			"integrity": "sha512-Si/Ep5yXmxTpUT1Fxgd8PjhK6amohcSCUR50QGK9FIeCGoxBZiH7gi+VSvFAZsC2z8XvvP/tJZthB2j/9UHfPA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/url": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/autop": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.7.0.tgz",
@@ -6467,6 +6896,483 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.2.0.tgz",
+			"integrity": "sha512-k2rqdxGVsc2//j7EFPAD7bsvDRzKhC+dfUbN8gdzCY0Gaw61bjQHhXC6GwGjQ2w+jcIAUwgH/eyztqNs6UUwbA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@emotion/react": "^11.7.1",
+				"@emotion/styled": "^11.6.0",
+				"@react-spring/web": "^9.4.5",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/blob": "^4.7.0",
+				"@wordpress/block-serialization-default-parser": "^5.7.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/commands": "^1.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keyboard-shortcuts": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/preferences": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/style-engine": "^2.7.0",
+				"@wordpress/token-list": "^3.7.0",
+				"@wordpress/url": "^4.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"@wordpress/wordcount": "^4.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"deepmerge": "^4.3.0",
+				"diff": "^4.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^2.1.0",
+				"parsel-js": "^1.1.2",
+				"postcss": "^8.4.21",
+				"postcss-prefix-selector": "^1.16.0",
+				"postcss-urlrebase": "^1.4.0",
+				"react-autosize-textarea": "^7.1.0",
+				"react-easy-crop": "^5.0.6",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/block-editor/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@wordpress/block-library": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.7.0.tgz",
+			"integrity": "sha512-VbjTCslzy6oGTR6tPwYyxtlh7UtiOatHrkxczzF2qafiuKoWCeH1pN8K+w91Kgi+rX0sIyd6F7q+EMN8pdl+ag==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/autop": "^4.7.0",
+				"@wordpress/blob": "^4.7.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/interactivity": "^6.7.0",
+				"@wordpress/interactivity-router": "^2.7.0",
+				"@wordpress/keyboard-shortcuts": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/patterns": "^2.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/reusable-blocks": "^5.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/server-side-render": "^5.7.0",
+				"@wordpress/url": "^4.7.0",
+				"@wordpress/viewport": "^6.7.0",
+				"@wordpress/wordcount": "^4.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"escape-html": "^1.0.3",
+				"fast-average-color": "^9.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^2.1.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/block-library/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/block-library/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
@@ -6555,6 +7461,209 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.7.0.tgz",
+			"integrity": "sha512-w01WuJFbSnBJ9UPgPtm0M5GZLGOfJF+EdKvonR3Jf3uApmzyCPoDeqc+UJ1MGERANXzwOOtcHqQM26hhTbG+Ug==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/keyboard-shortcuts": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"clsx": "^2.1.1",
+				"cmdk": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/commands/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/commands/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/commands/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/components": {
@@ -7002,6 +8111,57 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/core-data": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.7.0.tgz",
+			"integrity": "sha512-mpk8pDc9nbD+G/4JegL/rxEwz24wvAjdVuieb+Q1MjeHMeSTJrqx6tUN6uKyJJZGZtjfYjasRUmRBIpbsx7qAQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/sync": "^1.7.0",
+				"@wordpress/undo-manager": "^1.7.0",
+				"@wordpress/url": "^4.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"equivalent-key-map": "^0.2.2",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^2.1.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/data": {
 			"version": "10.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.7.0.tgz",
@@ -7407,6 +8567,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@wordpress/interactivity": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.7.0.tgz",
+			"integrity": "sha512-DWzcfrZ7JY7nKYeTO4hfwgxAWrI4xq5GuhpWiT70FGLX9Zr78BuxI1Nt3t15gVS6/IJGruUoiBtWTsE/1Z/Qjw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@preact/signals": "^1.2.2",
+				"preact": "^10.19.3"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/interactivity-router": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.7.0.tgz",
+			"integrity": "sha512-0Bhxjcnu/mhiwIXk89Da7EaBaRf1/p9mzwGoXoFlblVvD+FdMFg0X1C/9cUW6axg1aT7rm130U4tm4FDwqBSug==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/interactivity": "^6.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/is-shallow-equal": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.7.0.tgz",
@@ -7457,6 +8644,25 @@
 				"jest": ">=29"
 			}
 		},
+		"node_modules/@wordpress/keyboard-shortcuts": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.7.0.tgz",
+			"integrity": "sha512-9GmYcJ/jX27UM2sR07i/pGo4uQs/ry0F9K86+aMfR9Clq8PU40z0y+K4U2BEOSBJaVeaM2G2AA1XL68jc5DR8g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/keycodes": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/keycodes": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
@@ -7471,6 +8677,24 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/notices": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.7.0.tgz",
+			"integrity": "sha512-QF7PT36YHPgbk1xmHHAwn4absKzWy32zdZB/PybK7XktvsB1m9VK9uS0Jyw7wAdJrOwNkPiBkBTJR2LsUI41tg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/data": "^10.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.7.0.tgz",
@@ -7483,6 +8707,214 @@
 			},
 			"peerDependencies": {
 				"npm-package-json-lint": ">=6.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.7.0.tgz",
+			"integrity": "sha512-6aE/+bSsAqffzqWLKReN9o5Szk4zMyNzkCsclSPjNp/hBCY7HYKfqlD6TNqLWKLlHgw+mYmtw5gZho6U3hRO9Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/url": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/patterns/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/patterns/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/patterns/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
@@ -7501,6 +8933,210 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.7.0.tgz",
+			"integrity": "sha512-zbzmim/kqWjuBusZjkm5sruugX88TzbadpuNmYklMvsd3jNXpbyPXWfzGcdj/Cl2v6sC1Gbt88tkfif73iPHsQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/preferences/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/preferences/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/preferences/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
@@ -7628,6 +9264,211 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.7.0.tgz",
+			"integrity": "sha512-F4CPUtLMKPSDK+OdrJRRBFlA6yBHpfV2tfcrqpo95l06GskIrgr1IQpyLiFnVKZPhO82K5Y/R3NS0xwD2NxuRQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/block-editor": "^14.2.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/core-data": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/notices": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/url": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
@@ -7884,6 +9725,210 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@wordpress/server-side-render": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.7.0.tgz",
+			"integrity": "sha512-VXBluHj/WICCx4OcjZrcrBg+YxXbah1YL4n2yLWhDMENAL0p4Ne67EqrQjCGbIfpGUpNDCQhIXXzSJ3gNiuCMg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/api-fetch": "^7.7.0",
+				"@wordpress/blocks": "^13.7.0",
+				"@wordpress/components": "^28.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/url": "^4.7.0",
+				"fast-deep-equal": "^3.1.3"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@ariakit/core": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.10.tgz",
+			"integrity": "sha512-mX3EabQbfVh5uTjsTJ3+gjj7KGdTNhIN0qZHJd5Z2iPUnKl9NBy23Lgu6PEskpVsKAZ3proirjguD7U9fKMs/A==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@ariakit/react": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.11.tgz",
+			"integrity": "sha512-nLpPrmNcspqNhk4o+epsgeZfP1+Fkh4uIzNe5yrFkXolRkqHGKAxl4Hi82e0yxIBUbYbZIEwsZQQVceF1L6xrw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@ariakit/react-core": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.11.tgz",
+			"integrity": "sha512-i6KedWhjZkNC7tMEKO0eNjjq2HRPiHyGaBS2x2VaWwzBepoYtjyvxRXyqLJ3gaiNdlwckN1TZsRDfD+viy13IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.10",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
+			"version": "28.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.7.0.tgz",
+			"integrity": "sha512-oxF+pAZHJ3L9p42wMDeclo6P0TOZW1+U1pKmKju33aDsAwINOU2ELpVFyIEHkA9txn8VU4lxpnNIsYY6RGlW8w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/date": "^5.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/icons": "^10.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/primitives": "^4.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/date": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.7.0.tgz",
+			"integrity": "sha512-iMwGP/Sbz+CCgqxUUKg8W2sZiwvr9K1q7s0rHuy3YVJT46QDNpN0A6HGNmckI0z4C+CRDvOIa09OMgTz1igUAw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.7.0.tgz",
+			"integrity": "sha512-4cvi9ZIaz6IYRcOjVuALtDLPtzgt1zK+E9LskL0PAi3TJhoh746q28wv6ycP+KtJEiI+bsTf2Qu5dmCePGR/jA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/primitives": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/primitives": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.7.0.tgz",
+			"integrity": "sha512-PcAAIMT8+WqKB2HAeQlLmrcQyzyhNw9IeToJoxz+VKcc/7uLfGHplsDvtHY/X4jH8QlwlVwHSiqW/McTcxoUvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^6.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/shortcode": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.7.0.tgz",
@@ -7892,6 +9937,20 @@
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"memize": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/style-engine": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.7.0.tgz",
+			"integrity": "sha512-ISIUzoTxzMZQLY7dzwPlWaKG8mh5ZUBTALxyNlglHVlxoNyQ1e/Yw1duZySxSvnfdfVeKRw33iJO0iQQCxinsA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"change-case": "^4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7916,6 +9975,41 @@
 				"stylelint": "^14.2"
 			}
 		},
+		"node_modules/@wordpress/sync": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.7.0.tgz",
+			"integrity": "sha512-PhMezrdiMVTeEmi8f1z3MbCAuixBi8wXoTzQUe9wmsD+clM9uvw839KpNym/5ZMC5suADwa1TSGylLf/l3AZtQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/simple-peer": "^9.11.5",
+				"@wordpress/url": "^4.7.0",
+				"import-locals": "^2.0.0",
+				"lib0": "^0.2.42",
+				"simple-peer": "^9.11.0",
+				"y-indexeddb": "~9.0.11",
+				"y-protocols": "^1.0.5",
+				"y-webrtc": "~10.2.5",
+				"yjs": "~13.6.6"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/token-list": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.7.0.tgz",
+			"integrity": "sha512-joJ/J3NjzVIXN0PDV+BayyVm4ZNP1XInUI4XDuP1zNb++OEqcuX9OBa4cqNgzyNImRTZStjD/fPKs28BTrG87g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/undo-manager": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.7.0.tgz",
@@ -7930,11 +10024,57 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/url": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.7.0.tgz",
+			"integrity": "sha512-c9L3L4+YrygKtf5S7DKFP1wNbFvqPLp8Uub4VgPKWmlZnIB2hsRNXELba5qGHpPmzTg82KwXImRAuHSMrfr+LA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/viewport": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.7.0.tgz",
+			"integrity": "sha512-T05rktsX+xOgTekKKRIAwuK+FdtmOMQVfbkxtGW2RtfwBWc161ZdgXT0C3x+LWwzhocYg2ymwkM9Mm8/MBhgFw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/element": "^6.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/warning": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
 			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/wordcount": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.7.0.tgz",
+			"integrity": "sha512-NcxUhnkvdybK7V2c0w7A/SAiDByTrE/jbTxGwIHa3gh1YOofhwfFH9wGxFQp1ZUpoE9HZY6eS4HCScoWsEXJ0Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -8765,6 +10905,18 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+			"integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/aria-query": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
@@ -9094,6 +11246,12 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/autosize": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
+			"integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
+			"license": "MIT"
+		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -9357,7 +11515,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
 			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
@@ -9373,7 +11530,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
 			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
@@ -9562,7 +11718,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10068,7 +12223,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10174,7 +12328,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
@@ -10612,10 +12765,23 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cmdk": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
+			"integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-dialog": "1.0.5",
+				"@radix-ui/react-primitive": "1.0.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/co": {
@@ -10822,6 +12988,11 @@
 			"integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/computed-style": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+			"integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w=="
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -11890,7 +14061,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
 			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -11908,7 +14078,6 @@
 			"version": "4.3.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
 			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -12489,12 +14658,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"license": "MIT"
+		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1155343",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
 			"integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -12846,11 +15030,16 @@
 			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
 			"license": "MIT"
 		},
+		"node_modules/err-code": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+			"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+			"license": "MIT"
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
@@ -13097,7 +15286,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
@@ -14489,6 +16677,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/fast-average-color": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.4.0.tgz",
+			"integrity": "sha512-bvM8vV6YwK07dPbzFz77zJaBcfF6ABVfgNwaxVgXc2G+o0e/tzLCF9WU8Ryp1r0Nkk6JuJNsWCzbb4cLOMlB+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14960,7 +17157,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
 			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/find-up": {
@@ -15292,7 +17488,6 @@
 			"version": "11.5.4",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.5.4.tgz",
 			"integrity": "sha512-E+tb3/G6SO69POkdJT+3EpdMuhmtCh9EWuK4I1DnIC23L7tFPrl8vxP+LSovwaw6uUr73rUbpb4FgK011wbRJQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.4.0"
@@ -15491,6 +17686,12 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/get-browser-rtc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+			"integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+			"license": "MIT"
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -15517,6 +17718,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -15773,7 +17983,6 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -15889,7 +18098,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
 			"integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15955,7 +18163,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -16052,14 +18259,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
 			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/hoist-non-react-statics": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"react-is": "^16.7.0"
@@ -16069,7 +18274,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/homedir-polyfill": {
@@ -16429,7 +18633,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -16534,7 +18737,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parent-module": "^1.0.0",
@@ -16551,7 +18753,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -16586,6 +18787,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/import-locals": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-locals/-/import-locals-2.0.0.tgz",
+			"integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
+			"license": "MIT"
 		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
@@ -16675,6 +18882,15 @@
 			"deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
 		},
 		"node_modules/invert-kv": {
 			"version": "3.0.1",
@@ -16780,7 +18996,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
@@ -16918,7 +19133,6 @@
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
 			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -17519,6 +19733,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isomorphic.js": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+			"integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+			"license": "MIT",
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -19598,7 +21822,6 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -19628,7 +21851,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
@@ -20003,6 +22225,27 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lib0": {
+			"version": "0.2.97",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.97.tgz",
+			"integrity": "sha512-Q4d1ekgvufi9FiHkkL46AhecfNjznSL9MRNoJRQ76gBHS9OqU2ArfQK0FvBpuxgWeJeNI0LVgAYMIpsGeX4gYg==",
+			"license": "MIT",
+			"dependencies": {
+				"isomorphic.js": "^0.2.4"
+			},
+			"bin": {
+				"0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+				"0gentesthtml": "bin/gentesthtml.js",
+				"0serve": "bin/0serve.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
 		"node_modules/lie": {
@@ -20393,11 +22636,22 @@
 				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
+		"node_modules/line-height": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+			"integrity": "sha512-YExecgqPwnp5gplD2+Y8e8A5+jKpr25+DzMbFdI1/1UAr0FJrTFv4VkHLf8/6B590i1wUPJWMKKldkd/bdQ//w==",
+			"license": "MIT",
+			"dependencies": {
+				"computed-style": "~0.1.3"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
@@ -21337,7 +23591,6 @@
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
 			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -21347,7 +23600,6 @@
 			"version": "0.5.45",
 			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
 			"integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"moment": "^2.29.4"
@@ -21569,7 +23821,6 @@
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
 			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21817,6 +24068,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/normalize-wheel": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+			"integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -22056,7 +24313,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22709,7 +24965,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"callsites": "^3.0.0"
@@ -22728,7 +24983,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
@@ -22779,6 +25033,12 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
+		},
+		"node_modules/parsel-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.1.2.tgz",
+			"integrity": "sha512-D66DG2nKx4Yoq66TMEyCUHlR2STGqO7vsBrX7tgyS9cfQyO6XD5JyzOiflwmWN6a4wbUAqpmHqmrxlTQVGZcbA==",
+			"license": "MIT"
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
@@ -22850,7 +25110,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-scurry": {
@@ -22887,7 +25146,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -22904,7 +25162,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
 			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -23139,7 +25396,6 @@
 			"version": "8.4.45",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
 			"integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -23673,6 +25929,15 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-prefix-selector": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
+			"integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"postcss": ">4 <9"
+			}
+		},
 		"node_modules/postcss-reduce-initial": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
@@ -23804,12 +26069,33 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-urlrebase": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+			"integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.0"
+			}
+		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/preact": {
+			"version": "10.24.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.24.0.tgz",
+			"integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -23944,7 +26230,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.4.0",
@@ -23956,7 +26241,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/proto-list": {
@@ -24198,7 +26482,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24243,7 +26526,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -24310,7 +26592,6 @@
 			"version": "6.9.18",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.18.tgz",
 			"integrity": "sha512-4RgEES1iizvpaNtvcJz2fUOw5efuK5Jaix3+nY4yQvI6pxKKkFaoKZB1KtiXd8hawR2BGdcoJFS4NGDPketAYQ==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.13.1 || ^17.0.0 || ^18.0.0",
@@ -24329,11 +26610,25 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"license": "MIT",
+			"dependencies": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
 		"node_modules/react-colorful": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -24353,6 +26648,20 @@
 				"react": "^18.3.1"
 			}
 		},
+		"node_modules/react-easy-crop": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.8.tgz",
+			"integrity": "sha512-KjulxXhR5iM7+ATN2sGCum/IyDxGw7xT0dFoGcqUP+ysaPU5Ka7gnrDa2tUHFHUoMNyPrVZ05QA+uvMgC5ym/g==",
+			"license": "MIT",
+			"dependencies": {
+				"normalize-wheel": "^1.0.1",
+				"tslib": "^2.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.0",
+				"react-dom": ">=16.4.0"
+			}
+		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -24367,6 +26676,53 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.3",
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+			"integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-router": {
@@ -24399,6 +26755,29 @@
 			"peerDependencies": {
 				"react": ">=16.8",
 				"react-dom": ">=16.8"
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"invariant": "^2.2.4",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/read-cache": {
@@ -24509,7 +26888,6 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -24835,7 +27213,6 @@
 			"version": "1.22.8",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
 			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.13.0",
@@ -25936,6 +28313,59 @@
 			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
 			"license": "MIT"
 		},
+		"node_modules/simple-peer": {
+			"version": "9.11.1",
+			"resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
+			"integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"debug": "^4.3.2",
+				"err-code": "^3.0.1",
+				"get-browser-rtc": "^1.1.0",
+				"queue-microtask": "^1.2.3",
+				"randombytes": "^2.1.0",
+				"readable-stream": "^3.6.0"
+			}
+		},
+		"node_modules/simple-peer/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -26122,7 +28552,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -26417,7 +28846,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
@@ -26898,14 +29326,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
 			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
@@ -26955,7 +29381,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -27443,7 +29868,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -28515,11 +30939,31 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+			"integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/use-lilius": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
 			"integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^3.6.0"
@@ -28538,11 +30982,32 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
 			"integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
@@ -28552,7 +31017,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -30021,6 +32485,73 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/y-indexeddb": {
+			"version": "9.0.12",
+			"resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+			"integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.74"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			},
+			"peerDependencies": {
+				"yjs": "^13.0.0"
+			}
+		},
+		"node_modules/y-protocols": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+			"integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.85"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			},
+			"peerDependencies": {
+				"yjs": "^13.0.0"
+			}
+		},
+		"node_modules/y-webrtc": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.6.tgz",
+			"integrity": "sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==",
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.42",
+				"simple-peer": "^9.11.0",
+				"y-protocols": "^1.0.6"
+			},
+			"bin": {
+				"y-webrtc-signaling": "bin/server.js"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			},
+			"optionalDependencies": {
+				"ws": "^8.14.2"
+			},
+			"peerDependencies": {
+				"yjs": "^13.6.8"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -30041,7 +32572,6 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">= 6"
@@ -30083,6 +32613,23 @@
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yjs": {
+			"version": "13.6.19",
+			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.19.tgz",
+			"integrity": "sha512-GNKw4mEUn5yWU2QPHRx8jppxmCm9KzbBhB4qJLUJFiiYD0g/tDVgXQ7aPkyh01YO28kbs2J/BEbWBagjuWyejw==",
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.86"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@wordpress/blocks": "^13.7.0",
 				"@wp-playground/client": "^0.9.39",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -16,6 +17,7 @@
 				"@types/firefox-webext-browser": "^120.0.4",
 				"@types/react": "^18.3.5",
 				"@types/react-dom": "^18.3.0",
+				"@types/wordpress__blocks": "^12.5.14",
 				"@wordpress/scripts": "^29.0.0",
 				"concurrently": "^9.0.1",
 				"copy-webpack-plugin": "^12.0.2",
@@ -40,6 +42,47 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@ariakit/core": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
+			"integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
+			"integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.3.14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-core": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
+			"integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.3.11",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1978,7 +2021,6 @@
 			"version": "7.25.6",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
 			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -2121,6 +2163,209 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+			"integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.2.0",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.13.1",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+			"integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.0",
+				"@emotion/weak-memoize": "^0.4.0",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/css": {
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.0.tgz",
+			"integrity": "sha512-BUk99ylT+YHl+W/HN7nv1RCTkDYmKKqa1qbvM/qLSQEg61gipuBF5Hptk/2/ERmX2DCv0ccuFGhz9i0KSZOqPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/cache": "^11.13.0",
+				"@emotion/serialize": "^1.3.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.0"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+			"integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.13.3",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+			"integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/cache": "^11.13.0",
+				"@emotion/serialize": "^1.3.1",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+				"@emotion/utils": "^1.4.0",
+				"@emotion/weak-memoize": "^0.4.0",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.1.tgz",
+			"integrity": "sha512-dEPNKzBPU+vFPGa+z3axPRn8XVDetYORmDC0wAiej+TNcOZE70ZMJa0X7JdeoM6q/nWTMZeLpN/fTnD9o8MQBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.0",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/styled": {
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
+			"integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/is-prop-valid": "^1.3.0",
+				"@emotion/serialize": "^1.3.0",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+				"@emotion/utils": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0-rc.0",
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+			"integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
+			"integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.41.0",
@@ -2306,6 +2551,48 @@
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+			"integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@fluent/syntax": {
 			"version": "0.19.0",
@@ -4692,6 +4979,37 @@
 				"node": ">=14.16"
 			}
 		},
+		"node_modules/@tannin/compile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tannin/evaluate": "^1.2.0",
+				"@tannin/postfix": "^1.1.0"
+			}
+		},
+		"node_modules/@tannin/evaluate": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
+			"license": "MIT"
+		},
+		"node_modules/@tannin/plural-forms": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tannin/compile": "^1.1.0"
+			}
+		},
+		"node_modules/@tannin/postfix": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+			"license": "MIT"
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -4917,10 +5235,24 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/gradient-parser": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
+			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/har-format": {
 			"version": "1.2.15",
 			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
 			"integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/highlight-words-core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
+			"integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5031,6 +5363,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/mousetrap": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+			"integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "22.5.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
@@ -5068,7 +5406,6 @@
 			"version": "15.7.12",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
 			"integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/qs": {
@@ -5089,7 +5426,6 @@
 			"version": "18.3.5",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
 			"integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -5100,7 +5436,6 @@
 			"version": "18.3.0",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
 			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/react": "*"
@@ -5257,6 +5592,284 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/@types/wordpress__blocks": {
+			"version": "12.5.14",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.14.tgz",
+			"integrity": "sha512-eXEnCRKYu+39KEJ/OYpoYxWTATxI+eJHd+meMGZ14hYydFtxA0Y8M7zJT8D8f4klBo8wINLvP7zrO8vYrjWjPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/react": "*",
+				"@types/wordpress__shortcode": "*",
+				"@wordpress/components": "^27.2.0",
+				"@wordpress/data": "^9.13.0",
+				"@wordpress/element": "^5.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/compose": {
+			"version": "6.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+			"integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/dom": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/is-shallow-equal": "^4.58.0",
+				"@wordpress/keycodes": "^3.58.0",
+				"@wordpress/priority-queue": "^2.58.0",
+				"@wordpress/undo-manager": "^0.18.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/data": {
+			"version": "9.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+			"integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.35.0",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/is-shallow-equal": "^4.58.0",
+				"@wordpress/priority-queue": "^2.58.0",
+				"@wordpress/private-apis": "^0.40.0",
+				"@wordpress/redux-routine": "^4.58.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/deprecated": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.58.0.tgz",
+			"integrity": "sha512-knweE2lLEUxWRr6A48sHiO0ww5pPybGe2NVIZVq/y7EaYCMdpy6gYA0ZdVqMKZvtxKKqicJfwigcn+hinsTvUQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/dom": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.58.0.tgz",
+			"integrity": "sha512-t3xSr/nqekj2qwUGRAqSeGx6116JOBxzI+VBiUfZrjGEnuyKdLelXDEeYtcwbb7etMkj/6F60/NB7GTl5IwizQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^3.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/element": {
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+			"integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^2.58.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/escape-html": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.58.0.tgz",
+			"integrity": "sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/hooks": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+			"integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/i18n": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+			"integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.58.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/is-shallow-equal": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.58.0.tgz",
+			"integrity": "sha512-NH2lbXo/6ix1t4Zu9UBXpXNtoLwSaYmIRSyDH34XNb0ic8a7yjEOhYWVW3LTfSCv9dJVyxlM5TJPtL85q7LdeQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/keycodes": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.58.0.tgz",
+			"integrity": "sha512-Q/LRKpx8ndzuHlkxSQ2BD+NTYYKQPIneNNMng8hTAfyU7RFwXpqj06HpeOFGh4XIdPKCs/8hmucoLJRmmLmZJA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/priority-queue": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.58.0.tgz",
+			"integrity": "sha512-W+qCS8HJWsXG8gE6yK/H/IObowcghPrQMM3cQHtfd/U05yFNU1Bd/fbj3AO1fVRztktS47lIpi9m3ll1evPEHA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"requestidlecallback": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.40.0.tgz",
+			"integrity": "sha512-ZX/9Y8eA3C3K6LOj32bHFj+9tNV819CBd8+chqMmmlvQRcTngiuXbMbnSdZnnAr1gLQgNpH9PJ60dIwJnGSEtQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/redux-routine": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
+			"integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"rungen": "^0.3.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"redux": ">=4"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/undo-manager": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
+			"integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^4.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@types/wordpress__shortcode": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.6.tgz",
+			"integrity": "sha512-H8BVov7QWyLLoxCaI9QyZVC4zTi1mFkZ+eEKiXBCFlaJ0XV8UVfQk+cAetqD5mWOeWv2d4b8uzzyn0TTQ/ep2g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.12",
@@ -5552,6 +6165,26 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
+		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.12.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -5760,6 +6393,34 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/a11y": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.7.0.tgz",
+			"integrity": "sha512-qeh8TcJNNr9M0XL3OUDawBRrZypNLsnLjcXEBd6jp8Y4kOWxowmDDT6re1uToPdYTLLW2PZmZeBLYR9OS7pgpw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/dom-ready": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/autop": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.7.0.tgz",
+			"integrity": "sha512-mxcee/l5ElWy4EyDaQK8GowCTb45YHg6oVkqfgm/uuwZ4JKHmBL3FhbQjqjGn0klBmQL5lDUEA8D6WKYELHhSw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/babel-preset-default": {
 			"version": "8.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.7.0.tgz",
@@ -5795,6 +6456,96 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/blob": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.7.0.tgz",
+			"integrity": "sha512-JT6eMRNjgArGny5pTqC9fey5s4jA8u5msgkYLeiICm9T06ovXgxbaPToT7xnIKZKx5StrRV3wZNApNcylQmDKg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-serialization-default-parser": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.7.0.tgz",
+			"integrity": "sha512-G+f52f6CoSfB6YgBPo0kV51+EbsFG9782hnX1zNFeFuAVTs8dCXrMdoqxAfOUV0O0semnbLwClcQNNXRn8wz8g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/blocks": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.7.0.tgz",
+			"integrity": "sha512-JDe46DCW5QhrkKJs0dusKgSmwgFLQkFk7OgHxFpGkZHVkU1gViqh+dYMiEhbuIrAhbYkFFlbf0NcTrYSE12TAQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^4.7.0",
+				"@wordpress/blob": "^4.7.0",
+				"@wordpress/block-serialization-default-parser": "^5.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/hooks": "^4.7.0",
+				"@wordpress/html-entities": "^4.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/rich-text": "^7.7.0",
+				"@wordpress/shortcode": "^4.7.0",
+				"@wordpress/warning": "^3.7.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-is": "^18.3.0",
+				"remove-accents": "^0.5.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/browserslist-config": {
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.7.0.tgz",
@@ -5804,6 +6555,533 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components": {
+			"version": "27.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.6.0.tgz",
+			"integrity": "sha512-f+fXENkgrPs5GLo2yu9fEAdVX0KriEatRcjDUyw0+DbNbJR62sCdDtGdhJRW4jPUUoUowxaGO0y4+jvQWxnbyg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.3.12",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^3.58.0",
+				"@wordpress/compose": "^6.35.0",
+				"@wordpress/date": "^4.58.0",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/dom": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/escape-html": "^2.58.0",
+				"@wordpress/hooks": "^3.58.0",
+				"@wordpress/html-entities": "^3.58.0",
+				"@wordpress/i18n": "^4.58.0",
+				"@wordpress/icons": "^9.49.0",
+				"@wordpress/is-shallow-equal": "^4.58.0",
+				"@wordpress/keycodes": "^3.58.0",
+				"@wordpress/primitives": "^3.56.0",
+				"@wordpress/private-apis": "^0.40.0",
+				"@wordpress/rich-text": "^6.35.0",
+				"@wordpress/warning": "^2.58.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"downshift": "^6.0.15",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/a11y": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.58.0.tgz",
+			"integrity": "sha512-7NnJKl4+pxP6kV/jvXaJcZZCGzW7zaj6YeMnyjUd96cH4ta1ykBIveWgejerFOGsbK+88FnStcxSFj+dbDXs/w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/dom-ready": "^3.58.0",
+				"@wordpress/i18n": "^4.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/compose": {
+			"version": "6.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+			"integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/dom": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/is-shallow-equal": "^4.58.0",
+				"@wordpress/keycodes": "^3.58.0",
+				"@wordpress/priority-queue": "^2.58.0",
+				"@wordpress/undo-manager": "^0.18.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/data": {
+			"version": "9.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+			"integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.35.0",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/is-shallow-equal": "^4.58.0",
+				"@wordpress/priority-queue": "^2.58.0",
+				"@wordpress/private-apis": "^0.40.0",
+				"@wordpress/redux-routine": "^4.58.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/deprecated": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.58.0.tgz",
+			"integrity": "sha512-knweE2lLEUxWRr6A48sHiO0ww5pPybGe2NVIZVq/y7EaYCMdpy6gYA0ZdVqMKZvtxKKqicJfwigcn+hinsTvUQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/dom": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.58.0.tgz",
+			"integrity": "sha512-t3xSr/nqekj2qwUGRAqSeGx6116JOBxzI+VBiUfZrjGEnuyKdLelXDEeYtcwbb7etMkj/6F60/NB7GTl5IwizQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^3.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/dom-ready": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.58.0.tgz",
+			"integrity": "sha512-sDgRPjNBToRKgYrpwvMRv2Yc7/17+sp8hm/rRnbubwb+d/DbGkK4Tc/r4sNLSZCqUAtcBXq9uk1lzvhge3QUSg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+			"integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^2.58.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/escape-html": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.58.0.tgz",
+			"integrity": "sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+			"integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/html-entities": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.58.0.tgz",
+			"integrity": "sha512-FU7b6QZdwTCuLKq6wCl0IZqqOMcMRxMcekVVytzTse7hYk9dvL1qQL/U4eQ/CNyKqiT9u7fb5NKTQILOzoolVQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.58.0.tgz",
+			"integrity": "sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.58.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/is-shallow-equal": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.58.0.tgz",
+			"integrity": "sha512-NH2lbXo/6ix1t4Zu9UBXpXNtoLwSaYmIRSyDH34XNb0ic8a7yjEOhYWVW3LTfSCv9dJVyxlM5TJPtL85q7LdeQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.58.0.tgz",
+			"integrity": "sha512-Q/LRKpx8ndzuHlkxSQ2BD+NTYYKQPIneNNMng8hTAfyU7RFwXpqj06HpeOFGh4XIdPKCs/8hmucoLJRmmLmZJA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/priority-queue": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.58.0.tgz",
+			"integrity": "sha512-W+qCS8HJWsXG8gE6yK/H/IObowcghPrQMM3cQHtfd/U05yFNU1Bd/fbj3AO1fVRztktS47lIpi9m3ll1evPEHA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"requestidlecallback": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.40.0.tgz",
+			"integrity": "sha512-ZX/9Y8eA3C3K6LOj32bHFj+9tNV819CBd8+chqMmmlvQRcTngiuXbMbnSdZnnAr1gLQgNpH9PJ60dIwJnGSEtQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/redux-routine": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.58.0.tgz",
+			"integrity": "sha512-r0mMWFeJr93yPy2uY/M5+gdUUYj0Zu8+21OFFb5hyQ0z7UHIa3IdgQxzCaTbV1LDA1ZYJrjHeCnA6s4gNHjA2Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"rungen": "^0.3.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"redux": ">=4"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/rich-text": {
+			"version": "6.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.35.0.tgz",
+			"integrity": "sha512-h6/XftSqo9UQZebuNZyLfOVu+ButBLITW/BILsKeJhSpmM19VNdz8UhVGLp+xQPE+/GPCIMJrhhqipISDfc2Ig==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^3.58.0",
+				"@wordpress/compose": "^6.35.0",
+				"@wordpress/data": "^9.28.0",
+				"@wordpress/deprecated": "^3.58.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/escape-html": "^2.58.0",
+				"@wordpress/i18n": "^4.58.0",
+				"@wordpress/keycodes": "^3.58.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/undo-manager": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
+			"integrity": "sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^4.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/warning": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
+			"integrity": "sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/components/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@wordpress/components/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@wordpress/compose": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.7.0.tgz",
+			"integrity": "sha512-TjhGcw9n/XbiMT63POESs1TF9O6eQRVhAPrMan5t2yusQbog5KLk4TetOasIWxD80pu5sg9P5NuupuU/oSEBYQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/dom": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"@wordpress/priority-queue": "^3.7.0",
+				"@wordpress/undo-manager": "^1.7.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/data": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.7.0.tgz",
+			"integrity": "sha512-0NqDYIMOHdilSYoH6LRaq1CHcWlJiGP6xxkjI6pu2ZEf5mo9S/UblLCzVwaZMnhae/ZxEsgQQIypIQJJqor9uw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/is-shallow-equal": "^5.7.0",
+				"@wordpress/priority-queue": "^3.7.0",
+				"@wordpress/private-apis": "^1.7.0",
+				"@wordpress/redux-routine": "^5.7.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/date": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.58.0.tgz",
+			"integrity": "sha512-yFT7DU0H9W0lsDytMaVMmjho08X1LeBMIQMppxdtKB04Ujx58hVh7gtunOsstUQ7pVg23nE2eLaVfx5JOdjzAw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^3.58.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/date/node_modules/@wordpress/deprecated": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.58.0.tgz",
+			"integrity": "sha512-knweE2lLEUxWRr6A48sHiO0ww5pPybGe2NVIZVq/y7EaYCMdpy6gYA0ZdVqMKZvtxKKqicJfwigcn+hinsTvUQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.58.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/date/node_modules/@wordpress/hooks": {
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+			"integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
@@ -5821,6 +7099,47 @@
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/@wordpress/deprecated": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.7.0.tgz",
+			"integrity": "sha512-FMtYPk+yxvEAs1LDBHk1yHz48vlp/TWrTQeMph5ov7dpw4Xgfd9darXorsl4zudJVrB+Nn6dYrPmrS08rAXtQQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dom": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.7.0.tgz",
+			"integrity": "sha512-lGPEJHSHOT5Y9gWsX8V2tcsd5shDCTJqDxzL+pwDTfEsi/Os52nZCvzmavzGwRDzlm2Wmd3wNW+k/UCS/PhmXQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dom-ready": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.7.0.tgz",
+			"integrity": "sha512-moMbRCPNfgCc0dT0waEr0renEsptnDMV89fGpMijA66IyvYoYsxDT57w2JqHiaKbTvbIBmgdNgDjcVgZGv5JoA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
@@ -5843,6 +7162,48 @@
 			},
 			"peerDependencies": {
 				"@playwright/test": ">=1"
+			}
+		},
+		"node_modules/@wordpress/element": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.7.0.tgz",
+			"integrity": "sha512-d0kiN8DCNDNoh5P5xLb496amoadvjsSnkyJHmQsw17qP4dHZaSLONiMi9yh3NQlwIu0pcbbn3WI/9ENA79HlFQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^3.7.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/escape-html": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.7.0.tgz",
+			"integrity": "sha512-VqLQGNMs1BF6LnS+5eNjpM/sCUQhjn4QOfhDlWdVDi0ZxpZgssPzKhJ1ils/7FC0qF3vrMg8EH5xXxw2xz8A/w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
@@ -5935,6 +7296,130 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@wordpress/hooks": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.7.0.tgz",
+			"integrity": "sha512-EGHMsNCt+PyStm3o1JWujaTA+HKcTxuEXdSHBBFDavzsgOF13bxTf1LpDYgTZJT3K9TSMP983IwfckP5t66pDw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/html-entities": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.7.0.tgz",
+			"integrity": "sha512-dVhbaGyQaDFwMoZn5PT+d6amO3VYurVQN/bkUl6h6SeBNOsTY1DqUVzO0rLxFp8Is/4MOms61sFJL7nvWtkxaA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/i18n": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.7.0.tgz",
+			"integrity": "sha512-o1cq1zutE5rMAM//Ra1hRfgHuWNBxFtd7XNk+BuAcILRENMaEoqAoGBmGj9lRtOcqAj+cdoWxFjBIxRa67vIrg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^4.7.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/i18n/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@wordpress/icons": {
+			"version": "9.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+			"integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^5.35.0",
+				"@wordpress/primitives": "^3.56.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+			"integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^2.58.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/icons/node_modules/@wordpress/escape-html": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.58.0.tgz",
+			"integrity": "sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/icons/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/is-shallow-equal": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.7.0.tgz",
+			"integrity": "sha512-PW+OEkojwd8pZs7m8m9jVwVhLTA1kxmf01f0R2aC+bGfYvw0mlqcviCQTR6+EpRYpceh2nkDch2mD/LWT8c7ZA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/jest-console": {
 			"version": "8.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.7.0.tgz",
@@ -5970,6 +7455,20 @@
 			"peerDependencies": {
 				"@babel/core": ">=7",
 				"jest": ">=29"
+			}
+		},
+		"node_modules/@wordpress/keycodes": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.7.0.tgz",
+			"integrity": "sha512-x8I0xjRM8U0RnpFHWN9mA+x3MqjhJNBldiCpb59GTi3BIzPeDPgxbosAsAAgF0pYdDtGyiRkrOZA23NTia63TA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^5.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -6016,6 +7515,144 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/primitives": {
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.56.0.tgz",
+			"integrity": "sha512-NXBq1ODjl6inMWx/l7KCbATcjdoeIOqYeL9i9alqdAfWeKx1EH9PIvKWylIkqZk7erXxCxldiRkuyjTtwjNBxw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/element": "^5.35.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.35.0.tgz",
+			"integrity": "sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^2.58.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/@wordpress/escape-html": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.58.0.tgz",
+			"integrity": "sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/priority-queue": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.7.0.tgz",
+			"integrity": "sha512-WgKOhaQdaEeOxRLL49cp2YKfsZyUsR1qHoLid64Jux9FjFqLT8t52UTYJ796AhU4W0ifxf3R1SkNpW5zslxKOg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"requestidlecallback": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/private-apis": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.7.0.tgz",
+			"integrity": "sha512-H6bbWZRL7u2awmK14ZCz7OupeIjz1HxSlB785X53k9JZ5KsbSK/FCzAvOJ5vCU9poC1fa6IT33qkgx3JNX3JEA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/redux-routine": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.7.0.tgz",
+			"integrity": "sha512-KOU1+qFEDrptLY6lOQ3pTR+MZwe35dHfCp8xJHUJa/RI9jKULvXWrEIX0qhEMNWlinyQmwdTfmZqKxP8RuFzag==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"rungen": "^0.3.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"redux": ">=4"
+			}
+		},
+		"node_modules/@wordpress/redux-routine/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/rich-text": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.7.0.tgz",
+			"integrity": "sha512-is96sOolYVeE/58jUr6GxZKY1XGWrF988lT8FUg7U4u0KgdDSIEPLacs4USE8OoqxZYCIAnwSPenMXN+ZPvOfw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.7.0",
+				"@wordpress/compose": "^7.7.0",
+				"@wordpress/data": "^10.7.0",
+				"@wordpress/deprecated": "^4.7.0",
+				"@wordpress/element": "^6.7.0",
+				"@wordpress/escape-html": "^3.7.0",
+				"@wordpress/i18n": "^5.7.0",
+				"@wordpress/keycodes": "^4.7.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -6247,6 +7884,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@wordpress/shortcode": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.7.0.tgz",
+			"integrity": "sha512-sgIc7wnkpjGSrYulZn4++LRuj8xH0yDkWguBLeIDrOWHPgyDfqaW8wIZ0WGuQCPb8L9bKXdzkfVfiuVy4JvDNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"memize": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "22.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-22.7.0.tgz",
@@ -6265,11 +7916,24 @@
 				"stylelint": "^14.2"
 			}
 		},
+		"node_modules/@wordpress/undo-manager": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.7.0.tgz",
+			"integrity": "sha512-FHkwMD/jbe5jhVXfD9bSNhEivhMeszm20/ymEP6vAsLVJB2K25iAMOGvsq5jtznyJiqQzNUmvPERN0IKnaHQnA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^5.7.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/warning": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.7.0.tgz",
 			"integrity": "sha512-wGbQfPlf8YV6gGhcGPYWUhHORct4xaBQSaDTJrwzlgHYyrrJUVXXgZxaM4+Aa23zQoA13nvFQHvfssOkwdh65g==",
-			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -6971,7 +8635,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.0"
@@ -7690,6 +9353,39 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
 			"version": "0.4.11",
 			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
@@ -8382,7 +10078,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pascal-case": "^3.1.2",
@@ -8468,7 +10163,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
 			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -8495,7 +10189,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
 			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"camel-case": "^4.1.2",
@@ -8813,6 +10506,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/clipboard": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+			"integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+			"license": "MIT",
+			"dependencies": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
+		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8904,6 +10608,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8926,7 +10640,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "1.1.3"
@@ -8936,14 +10649,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colorette": {
@@ -9102,6 +10813,13 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/compute-scroll-into-view": {
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+			"integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9349,7 +11067,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
 			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -10067,7 +11784,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cwd": {
@@ -10170,6 +11886,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -10199,7 +11926,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10337,7 +12063,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10716,6 +12441,12 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"license": "MIT"
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10891,7 +12622,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -10910,6 +12640,30 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/downshift": {
+			"version": "6.1.12",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+			"integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.14.8",
+				"compute-scroll-into-view": "^1.0.17",
+				"prop-types": "^15.7.2",
+				"react-is": "^17.0.2",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.12.0"
+			}
+		},
+		"node_modules/downshift/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dtrace-provider": {
 			"version": "0.8.8",
@@ -11001,6 +12755,27 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
+		},
+		"node_modules/encoding/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11064,6 +12839,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+			"license": "MIT"
 		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
@@ -13175,6 +14956,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -13500,6 +15288,32 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
+		"node_modules/framer-motion": {
+			"version": "11.5.4",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.5.4.tgz",
+			"integrity": "sha512-E+tb3/G6SO69POkdJT+3EpdMuhmtCh9EWuK4I1DnIC23L7tFPrl8vxP+LSovwaw6uUr73rUbpb4FgK011wbRJQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -13816,6 +15630,16 @@
 				"node": ">=14.14"
 			}
 		},
+		"node_modules/gettext-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+			"license": "MIT",
+			"dependencies": {
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -14000,6 +15824,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+			"license": "MIT",
+			"dependencies": {
+				"delegate": "^3.1.2"
+			}
+		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -14051,6 +15884,15 @@
 			"integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/gradient-parser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+			"integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -14200,12 +16042,35 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
 			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"capital-case": "^1.0.4",
 				"tslib": "^2.0.3"
 			}
+		},
+		"node_modules/highlight-words-core": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/homedir-polyfill": {
 			"version": "1.0.3",
@@ -14305,6 +16170,12 @@
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"node_modules/hpq": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+			"integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+			"license": "MIT"
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "3.0.0",
@@ -15399,6 +17270,12 @@
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
 		},
 		"node_modules/is-regex": {
@@ -18799,7 +20676,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
@@ -19112,6 +20988,12 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
+		},
+		"node_modules/memize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
+			"license": "MIT"
 		},
 		"node_modules/meow": {
 			"version": "9.0.0",
@@ -19457,10 +21339,28 @@
 			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/moment-timezone": {
+			"version": "0.5.45",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+			"integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"moment": "^2.29.4"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mousetrap": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+			"license": "Apache-2.0 WITH LLVM-exception"
 		},
 		"node_modules/mrmime": {
 			"version": "2.0.0",
@@ -19732,7 +21632,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lower-case": "^2.0.2",
@@ -20670,7 +22569,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -20801,7 +22699,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -20896,7 +22793,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -20907,7 +22803,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
 			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -22411,6 +24306,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/re-resizable": {
+			"version": "6.9.18",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.18.tgz",
+			"integrity": "sha512-4RgEES1iizvpaNtvcJz2fUOw5efuK5Jaix3+nY4yQvI6pxKKkFaoKZB1KtiXd8hawR2BGdcoJFS4NGDPketAYQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -22421,6 +24327,17 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-colorful": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -22440,7 +24357,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-refresh": {
@@ -22677,6 +24593,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redux": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+			"integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.9.2"
+			}
+		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -22723,7 +24648,6 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/regenerator-transform": {
@@ -22848,6 +24772,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"license": "MIT"
+		},
+		"node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"license": "MIT"
+		},
+		"node_modules/requestidlecallback": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+			"license": "MIT"
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -22865,6 +24807,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
 		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
@@ -23178,6 +25126,12 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
+			"license": "MIT"
+		},
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -23375,6 +25329,12 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+			"license": "MIT"
+		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -23490,7 +25450,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
 			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"no-case": "^3.0.4",
@@ -23608,6 +25567,12 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -23748,6 +25713,198 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/showdown": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"yargs": "^14.2"
+			},
+			"bin": {
+				"showdown": "bin/showdown.js"
+			}
+		},
+		"node_modules/showdown/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/cliui": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			}
+		},
+		"node_modules/showdown/node_modules/emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"license": "MIT"
+		},
+		"node_modules/showdown/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/showdown/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/showdown/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/showdown/node_modules/string-width": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/wrap-ansi": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
+		"node_modules/showdown/node_modules/yargs": {
+			"version": "14.2.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^5.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^15.0.1"
+			}
+		},
+		"node_modules/showdown/node_modules/yargs-parser": {
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
 		"node_modules/side-channel": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -23772,6 +25929,12 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-html-tokenizer": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+			"license": "MIT"
 		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
@@ -23874,7 +26037,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
 			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dot-case": "^3.0.4",
@@ -24732,6 +26894,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -24883,6 +27052,15 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/tannin": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tannin/plural-forms": "^1.1.0"
 			}
 		},
 		"node_modules/tapable": {
@@ -25223,6 +27401,12 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"license": "MIT"
 		},
 		"node_modules/titleize": {
@@ -25657,7 +27841,6 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
 			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsutils": {
@@ -26210,7 +28393,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
 			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
@@ -26220,7 +28402,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
 			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.3"
@@ -26333,6 +28514,39 @@
 			"integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/use-lilius": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
+			"integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"date-fns": "^3.6.0"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/use-memo-one": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+			"integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -27455,6 +29669,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.15",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@types/react": "^18.3.5",
 		"@types/react-dom": "^18.3.0",
 		"@types/wordpress__blocks": "^12.5.14",
+		"@types/wordpress__block-library": "^2.6.3",
 		"@wordpress/scripts": "^29.0.0",
 		"concurrently": "^9.0.1",
 		"copy-webpack-plugin": "^12.0.2",
@@ -38,6 +39,7 @@
 		"wp-types": "^4.66.1"
 	},
 	"dependencies": {
+		"@wordpress/block-library": "^9.7.0",
 		"@wordpress/blocks": "^13.7.0",
 		"@wp-playground/client": "^0.9.39",
 		"react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@types/firefox-webext-browser": "^120.0.4",
 		"@types/react": "^18.3.5",
 		"@types/react-dom": "^18.3.0",
+		"@types/wordpress__blocks": "^12.5.14",
 		"@wordpress/scripts": "^29.0.0",
 		"concurrently": "^9.0.1",
 		"copy-webpack-plugin": "^12.0.2",
@@ -37,6 +38,7 @@
 		"wp-types": "^4.66.1"
 	},
 	"dependencies": {
+		"@wordpress/blocks": "^13.7.0",
 		"@wp-playground/client": "^0.9.39",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
 	"type": "module",
 	"scripts": {
-		"build": "webpack",
+		"build:production": "rm -rf build/production && webpack --env mode=production",
+		"build:firefox": "rm -rf build/firefox && webpack --env target=firefox",
+		"build:chrome": "rm -rf build/chrome && webpack --env target=chrome",
 		"watch": "npm run watch:firefox",
 		"watch:firefox": "webpack --watch --env target=firefox",
 		"watch:chrome": "webpack --watch --env target=chrome",
 		"start": "npm run start:firefox",
-		"start:firefox": "concurrently \"npm:watch:firefox\" \"npm:web-ext:run:firefox\"",
-		"start:chrome": "concurrently \"npm:watch:chrome\" \"npm:web-ext:run:chrome\"",
+		"start:firefox": "npm run build:firefox && concurrently \"npm:watch:firefox\" \"npm:web-ext:run:firefox\"",
+		"start:chrome": "npm run build:chrome && concurrently \"npm:watch:chrome\" \"npm:web-ext:run:chrome\"",
 		"start:noreload": "npm run web-ext:run:firefox -- --no-reload",
 		"web-ext:run:firefox": "web-ext -s build/firefox run --target firefox-desktop",
 		"web-ext:run:chrome": "web-ext -s build/chrome run --target chromium --arg='--disable-search-engine-choice-screen'",

--- a/src/parser/cleanHtml.ts
+++ b/src/parser/cleanHtml.ts
@@ -1,0 +1,8 @@
+import { pasteHandler } from '@wordpress/blocks';
+
+export function cleanHtml( html: string ): string {
+	return pasteHandler( {
+		mode: 'INLINE',
+		HTML: html,
+	} );
+}

--- a/src/parser/cleanHtml.ts
+++ b/src/parser/cleanHtml.ts
@@ -1,8 +1,19 @@
 import { pasteHandler } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 export function cleanHtml( html: string ): string {
+	init();
 	return pasteHandler( {
 		mode: 'INLINE',
 		HTML: html,
 	} );
+}
+
+let isInitialized = false;
+function init() {
+	if ( isInitialized ) {
+		return;
+	}
+	registerCoreBlocks();
+	isInitialized = true;
 }

--- a/src/parser/cleanHtml.ts
+++ b/src/parser/cleanHtml.ts
@@ -1,12 +1,13 @@
-import { pasteHandler } from '@wordpress/blocks';
+import { pasteHandler, serialize } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
 export function cleanHtml( html: string ): string {
 	init();
-	return pasteHandler( {
-		mode: 'INLINE',
+	const blocks = pasteHandler( {
+		mode: 'BLOCKS',
 		HTML: html,
 	} );
+	return serialize( blocks );
 }
 
 let isInitialized = false;

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AppBus } from '@/bus/AppBus';
 import { Message } from '@/bus/Message';
 import { ContentBus } from '@/bus/ContentBus';
+import { cleanHtml } from '@/parser/cleanHtml';
 
 enum section {
 	title = 1,
@@ -9,11 +10,16 @@ enum section {
 	content,
 }
 
+interface SectionContent {
+	originalHtml: string;
+	cleanHtml: string;
+}
+
 export function SelectContent( props: { onExit: () => void } ) {
 	const { onExit } = props;
-	const [ title, setTitle ] = useState< string >();
-	const [ content, setContent ] = useState< string >();
-	const [ date, setDate ] = useState< string >();
+	const [ title, setTitle ] = useState< SectionContent >();
+	const [ content, setContent ] = useState< SectionContent >();
+	const [ date, setDate ] = useState< SectionContent >();
 	const [ lastClickedElement, setLastClickedElement ] = useState< string >();
 	const [ waitingForSelection, setWaitingForSelection ] = useState<
 		section | false
@@ -34,15 +40,27 @@ export function SelectContent( props: { onExit: () => void } ) {
 	}, [] );
 
 	if ( lastClickedElement ) {
+		const original = lastClickedElement;
+		const clean = cleanHtml( original );
+
 		switch ( waitingForSelection ) {
 			case section.title:
-				setTitle( lastClickedElement );
+				setTitle( {
+					originalHtml: original,
+					cleanHtml: clean,
+				} );
 				break;
 			case section.date:
-				setDate( lastClickedElement );
+				setDate( {
+					originalHtml: original,
+					cleanHtml: clean,
+				} );
 				break;
 			case section.content:
-				setContent( lastClickedElement );
+				setContent( {
+					originalHtml: original,
+					cleanHtml: clean,
+				} );
 				break;
 		}
 		setWaitingForSelection( false );
@@ -66,7 +84,7 @@ export function SelectContent( props: { onExit: () => void } ) {
 			</button>
 			<Section
 				label="Title"
-				value={ title }
+				content={ title }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&
@@ -78,7 +96,7 @@ export function SelectContent( props: { onExit: () => void } ) {
 			/>
 			<Section
 				label="Date"
-				value={ date }
+				content={ date }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&
@@ -90,7 +108,7 @@ export function SelectContent( props: { onExit: () => void } ) {
 			/>
 			<Section
 				label="Content"
-				value={ content }
+				content={ content }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&
@@ -108,14 +126,14 @@ export function SelectContent( props: { onExit: () => void } ) {
 
 function Section( props: {
 	label: string;
-	value: string | undefined;
+	content: SectionContent | undefined;
 	disabled: boolean;
 	waitingForSelection: boolean;
 	onWaitingForSelection: ( isWaiting: boolean ) => void;
 } ) {
 	const {
 		label,
-		value,
+		content,
 		disabled,
 		waitingForSelection,
 		onWaitingForSelection,
@@ -151,7 +169,10 @@ function Section( props: {
 					</button>
 				) }
 			</div>
-			<div style={ { paddingTop: '1rem' } }>{ value ?? 'Not found' }</div>
+			<div style={ { paddingTop: '1rem' } }>
+				{ content?.originalHtml ?? 'Not found' }
+			</div>
+			<div style={ { paddingTop: '1rem' } }>{ content?.cleanHtml }</div>
 		</div>
 	);
 }

--- a/src/ui/preview/PreviewTabBar.tsx
+++ b/src/ui/preview/PreviewTabBar.tsx
@@ -22,6 +22,7 @@ export function PreviewTabBar( props: {
 					type="radio"
 					onClick={ () => onChange( index ) }
 					checked={ value === index }
+					readOnly
 				/>
 				<label htmlFor={ key }>{ label }</label>
 			</div>

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -9,9 +9,7 @@ module.exports = function ( env ) {
 		targets = [ env.target ];
 	}
 
-	// We must always build for production because the development builds will have unsafe-eval in the code, which the
-	// browsers don't like.
-	const mode = 'production';
+	const mode = env.mode || 'development';
 
 	let modules = [];
 	for ( const target of targets ) {
@@ -23,7 +21,13 @@ module.exports = function ( env ) {
 
 // Build the extension.
 function extensionModules( mode, target ) {
-	const targetPath = path.resolve( __dirname, 'build', target );
+	let outputDir = path.resolve( __dirname, 'build' );
+	if ( mode === 'production' ) {
+		outputDir = path.resolve( outputDir, 'production' );
+	}
+	const targetPath = path.resolve( outputDir, target );
+
+	const devtool = mode === 'production' ? false : 'cheap-module-source-map';
 	const resolve = {
 		extensions: [ '.ts', '.tsx', '.js' ],
 		plugins: [ new TsconfigPathsPlugin() ],
@@ -41,6 +45,7 @@ function extensionModules( mode, target ) {
 		// Extension background script.
 		{
 			mode,
+			devtool,
 			resolve,
 			module,
 			entry: './src/extension/background.ts',
@@ -66,6 +71,7 @@ function extensionModules( mode, target ) {
 		// Extension content script.
 		{
 			mode,
+			devtool,
 			resolve,
 			module,
 			entry: './src/extension/content.ts',
@@ -77,6 +83,7 @@ function extensionModules( mode, target ) {
 		// The app.
 		{
 			mode,
+			devtool,
 			resolve,
 			module,
 			entry: './src/ui/main.ts',


### PR DESCRIPTION
This PR makes it so that we call the [`pasteHandler()`](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/src/api/raw-handling/paste-handler.js#L79) when a user clicks on an element. We don't do anything with the data yet, that will be implemented in future PRs.

## Build tooling changes
Previously, webpack was always being run in `production` mode, which meant that in development the code was minified and there were no source maps. Now, webpack can also be called in `development` mode. We now have the following scripts:

- `build:production`: builds both firefox and chrome versions in `production` mode, into` build/production`
- `build:firefox`: builds firefox version only, in development mode, into `build/firefox`
- `build:chrome`: builds chrome version only, in development mode, into `build/chrome`

The development builds now have source maps, which means we can debug using the browser's debugger.


## Screen capture

<img width="781" alt="Screenshot 2024-09-17 at 15 14 15" src="https://github.com/user-attachments/assets/739eb7e3-85b5-46ac-bcd4-a24fe7c54864">
