### PR TITLE
Iterate on blog post flow

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+/* eslint-disable react/no-is-mounted */
 
 import { PlaygroundClient } from '@wp-playground/client';
 import { WP_REST_API_Post } from 'wp-types';
@@ -21,27 +22,19 @@ export class ApiClient {
 		return this._siteUrl;
 	}
 
-	async createPost(): Promise< void > {
-		const response = await this.playgroundClient.request( {
-			url: `/index.php?rest_route=/wp/v2/posts`,
-			method: 'POST',
-			body: {
-				title:
-					'New Post from API Client - ' +
-					( Math.random() + 1 ).toString( 36 ).substring( 7 ),
-				content: 'This is a new post created via the API client.',
-				status: 'publish',
+	async createPost( data: { guid: string } ): Promise< Post > {
+		const { guid } = data;
+		const post = ( await this.post( '/liberated_posts', {
+			meta: {
+				guid,
 			},
-		} );
-		console.log( response, response.json );
+		} ) ) as WP_REST_API_Post;
+
+		return { id: post.id, title: post.title.raw ?? '' };
 	}
 
 	async getPosts(): Promise< Post[] > {
-		// eslint-disable-next-line react/no-is-mounted
-		const response = ( await this.get(
-			'/wp/v2/posts'
-		) ) as WP_REST_API_Post[];
-
+		const response = ( await this.get( '/posts' ) ) as WP_REST_API_Post[];
 		return response.map( ( post ) => {
 			return {
 				id: post.id,
@@ -52,10 +45,24 @@ export class ApiClient {
 
 	private async get( route: string ): Promise< object > {
 		const response = await this.playgroundClient.request( {
-			url: `/index.php?rest_route=${ route }`,
+			url: `/index.php?rest_route=/wp/v2${ route }`,
 			method: 'GET',
 		} );
 		if ( response.httpStatusCode !== 200 ) {
+			console.error( response );
+			throw Error( response.json.message );
+		}
+		return response.json;
+	}
+
+	private async post( route: string, body: object ): Promise< object > {
+		const response = await this.playgroundClient.request( {
+			url: `/index.php?rest_route=/wp/v2${ route }`,
+			method: 'POST',
+			body: JSON.stringify( body ),
+		} );
+		if ( response.httpStatusCode !== 201 ) {
+			console.error( response );
 			throw Error( response.json.message );
 		}
 		return response.json;
@@ -63,3 +70,4 @@ export class ApiClient {
 }
 
 /* eslint-enable camelcase */
+/* eslint-enable react/no-is-mounted */

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -25,6 +25,12 @@ export class ApiClient {
 		} ) ) as Post;
 	}
 
+	async updatePost( id: number, data: { title: string } ): Promise< Post > {
+		return ( await this.post( `/liberated_posts/${ id }`, {
+			title: data.title,
+		} ) ) as Post;
+	}
+
 	async getPostByGuid( guid: string ): Promise< Post | null > {
 		return null;
 	}
@@ -51,7 +57,7 @@ export class ApiClient {
 			method: 'POST',
 			body: JSON.stringify( body ),
 		} );
-		if ( response.httpStatusCode !== 201 ) {
+		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
 			console.error( response );
 			throw Error( response.json.message );
 		}

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -1,13 +1,7 @@
-/* eslint-disable camelcase */
 /* eslint-disable react/no-is-mounted */
 
 import { PlaygroundClient } from '@wp-playground/client';
-import { WP_REST_API_Post } from 'wp-types';
-
-export interface Post {
-	id: number;
-	title: string;
-}
+import { Post } from '@/api/Post';
 
 export class ApiClient {
 	private readonly playgroundClient: PlaygroundClient;
@@ -24,23 +18,15 @@ export class ApiClient {
 
 	async createPost( data: { guid: string } ): Promise< Post > {
 		const { guid } = data;
-		const post = ( await this.post( '/liberated_posts', {
+		return ( await this.post( '/liberated_posts', {
 			meta: {
 				guid,
 			},
-		} ) ) as WP_REST_API_Post;
-
-		return { id: post.id, title: post.title.raw ?? '' };
+		} ) ) as Post;
 	}
 
 	async getPosts(): Promise< Post[] > {
-		const response = ( await this.get( '/posts' ) ) as WP_REST_API_Post[];
-		return response.map( ( post ) => {
-			return {
-				id: post.id,
-				title: post.title.rendered,
-			};
-		} );
+		return ( await this.get( '/posts' ) ) as Post[];
 	}
 
 	private async get( route: string ): Promise< object > {
@@ -69,5 +55,4 @@ export class ApiClient {
 	}
 }
 
-/* eslint-enable camelcase */
 /* eslint-enable react/no-is-mounted */

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -31,6 +31,7 @@ export class ApiClient {
 		} ) ) as Post;
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async getPostByGuid( guid: string ): Promise< Post | null > {
 		return null;
 	}

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -25,6 +25,10 @@ export class ApiClient {
 		} ) ) as Post;
 	}
 
+	async getPostByGuid( guid: string ): Promise< Post | null > {
+		return null;
+	}
+
 	async getPosts(): Promise< Post[] > {
 		return ( await this.get( '/posts' ) ) as Post[];
 	}

--- a/src/api/Post.ts
+++ b/src/api/Post.ts
@@ -1,0 +1,7 @@
+/* eslint-disable camelcase */
+
+import { WP_REST_API_Post } from 'wp-types';
+
+export interface Post extends WP_REST_API_Post {}
+
+/* eslint-enable camelcase */

--- a/src/bus/ContentBus.ts
+++ b/src/bus/ContentBus.ts
@@ -4,6 +4,14 @@ import MessageSender = browser.runtime.MessageSender;
 enum Actions {
 	EnableHighlighting = 1,
 	DisableHighlighting,
+	GetCurrentUrl,
+}
+
+async function getCurrentUrl(): Promise< string > {
+	return sendMessageToContent( {
+		action: Actions.GetCurrentUrl,
+		payload: {},
+	} );
 }
 
 async function enableHighlighting(): Promise< void > {
@@ -27,6 +35,7 @@ export const ContentBus = {
 	stopListening,
 	enableHighlighting,
 	disableHighlighting,
+	getCurrentUrl,
 };
 
 let listener: (

--- a/src/bus/Message.ts
+++ b/src/bus/Message.ts
@@ -6,4 +6,7 @@ export interface Message {
 	payload: object;
 }
 
-export type Listener = ( message: Message ) => void;
+export type Listener = (
+	message: Message,
+	sendResponse: ( response: any ) => void
+) => void;

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -19,6 +19,9 @@ ContentBus.listen( ( message: Message, sendResponse: any ) => {
 			disableHighlightingCursor();
 			removeStyle();
 			break;
+		case ContentBus.actions.GetCurrentUrl:
+			sendResponse( document.documentURI );
+			break;
 		default:
 			console.error( `Unknown action: ${ message.action }` );
 			break;

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -4,7 +4,7 @@ import { AppBus } from '@/bus/AppBus';
 
 let currentElement: HTMLElement | null = null;
 
-ContentBus.listen( ( message: Message ) => {
+ContentBus.listen( ( message: Message, sendResponse: any ) => {
 	switch ( message.action ) {
 		case ContentBus.actions.EnableHighlighting:
 			document.body.addEventListener( 'mouseover', onMouseOver );

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -4,29 +4,31 @@ import { AppBus } from '@/bus/AppBus';
 
 let currentElement: HTMLElement | null = null;
 
-ContentBus.listen( ( message: Message, sendResponse: any ) => {
-	switch ( message.action ) {
-		case ContentBus.actions.EnableHighlighting:
-			document.body.addEventListener( 'mouseover', onMouseOver );
-			document.body.addEventListener( 'mouseout', onMouseOut );
-			document.body.addEventListener( 'click', onClick );
-			enableHighlightingCursor();
-			break;
-		case ContentBus.actions.DisableHighlighting:
-			document.body.removeEventListener( 'mouseover', onMouseOver );
-			document.body.removeEventListener( 'mouseout', onMouseOut );
-			document.body.removeEventListener( 'click', onClick );
-			disableHighlightingCursor();
-			removeStyle();
-			break;
-		case ContentBus.actions.GetCurrentUrl:
-			sendResponse( document.documentURI );
-			break;
-		default:
-			console.error( `Unknown action: ${ message.action }` );
-			break;
+ContentBus.listen(
+	( message: Message, sendResponse: ( response?: any ) => void ) => {
+		switch ( message.action ) {
+			case ContentBus.actions.EnableHighlighting:
+				document.body.addEventListener( 'mouseover', onMouseOver );
+				document.body.addEventListener( 'mouseout', onMouseOut );
+				document.body.addEventListener( 'click', onClick );
+				enableHighlightingCursor();
+				break;
+			case ContentBus.actions.DisableHighlighting:
+				document.body.removeEventListener( 'mouseover', onMouseOver );
+				document.body.removeEventListener( 'mouseout', onMouseOut );
+				document.body.removeEventListener( 'click', onClick );
+				disableHighlightingCursor();
+				removeStyle();
+				break;
+			case ContentBus.actions.GetCurrentUrl:
+				sendResponse( document.documentURI );
+				break;
+			default:
+				console.error( `Unknown action: ${ message.action }` );
+				break;
+		}
 	}
-} );
+);
 
 function onClick( event: MouseEvent ) {
 	event.preventDefault();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -84,19 +84,26 @@ function App() {
 	}, [ location ] );
 
 	const session = useRouteLoaderData( 'session' ) as Session;
+	const [ playgroundClient, setPlaygroundClient ] =
+		useState< PlaygroundClient >();
 	const [ apiClient, setApiClient ] = useState< ApiClient >();
-	const sectionContext: SessionContext = { session, apiClient };
+	const sectionContext: SessionContext = {
+		session,
+		apiClient,
+		playgroundClient,
+	};
 
 	const preview = ! session ? (
 		<PlaceholderPreview />
 	) : (
 		<Preview
-			onReady={ async ( playgroundClient: PlaygroundClient ) => {
-				const client = new ApiClient(
-					playgroundClient,
-					await playgroundClient.absoluteUrl
+			onReady={ async ( client: PlaygroundClient ) => {
+				// Because client is "function-y", we need to wrap it in a function so that React doesn't call it.
+				// See: https://react.dev/reference/react/useState#im-trying-to-set-state-to-a-function-but-it-gets-called-instead.
+				setPlaygroundClient( () => client );
+				setApiClient(
+					new ApiClient( client, await client.absoluteUrl )
 				);
-				setApiClient( client );
 			} }
 		/>
 	);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,7 @@ import { PlaceholderPreview } from '@/ui/preview/PlaceholderPreview';
 import { SessionContext, SessionProvider } from '@/ui/session/SessionProvider';
 import { ApiClient } from '@/api/ApiClient';
 import { BlogPostFlow } from '@/ui/flows/blog-post/BlogPostFlow';
+import { PlaygroundClient } from '@wp-playground/client';
 
 export const Screens = {
 	home: () => '/start/home',
@@ -89,7 +90,15 @@ function App() {
 	const preview = ! session ? (
 		<PlaceholderPreview />
 	) : (
-		<Preview onReady={ setApiClient } />
+		<Preview
+			onReady={ async ( playgroundClient: PlaygroundClient ) => {
+				const client = new ApiClient(
+					playgroundClient,
+					await playgroundClient.absoluteUrl
+				);
+				setApiClient( client );
+			} }
+		/>
 	);
 
 	return (

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -15,7 +15,7 @@ enum Steps {
 export function BlogPostFlow() {
 	const [ currentStep, setCurrentStep ] = useState( Steps.start );
 	const [ postUrl, setPostUrl ] = useState< string >();
-	const { apiClient } = useSessionContext();
+	const { apiClient, playgroundClient } = useSessionContext();
 
 	// Proceed from loading screen once the apiClient is ready.
 	if ( currentStep === Steps.loading && postUrl && !! apiClient ) {
@@ -35,8 +35,8 @@ export function BlogPostFlow() {
 			return post;
 		};
 		getOrCreatePost()
-			.then( ( post: Post ) => {
-				console.log( post );
+			.then( async ( post: Post ) => {
+				await playgroundClient.goTo( post.link );
 			} )
 			.catch( ( err ) => console.error( err ) );
 	}, [ postUrl, apiClient ] );

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -14,23 +14,23 @@ enum Steps {
 
 export function BlogPostFlow() {
 	const [ currentStep, setCurrentStep ] = useState( Steps.start );
-	const [ postUrl, setPostUrl ] = useState< string >();
+	const [ sourcePostUrl, setSourcePostUrl ] = useState< string >();
 	const { apiClient, playgroundClient } = useSessionContext();
 
 	// Proceed from loading screen once the apiClient is ready.
-	if ( currentStep === Steps.loading && postUrl && !! apiClient ) {
+	if ( currentStep === Steps.loading && sourcePostUrl && !! apiClient ) {
 		setCurrentStep( Steps.selectContent );
 	}
 
 	// Get existing post from the API, or create a new one.
 	useEffect( () => {
-		if ( ! postUrl || ! apiClient ) {
+		if ( ! sourcePostUrl || ! apiClient ) {
 			return;
 		}
 		const getOrCreatePost = async (): Promise< Post > => {
-			let post = await apiClient.getPostByGuid( postUrl );
+			let post = await apiClient.getPostByGuid( sourcePostUrl );
 			if ( ! post ) {
-				post = await apiClient.createPost( { guid: postUrl } );
+				post = await apiClient.createPost( { guid: sourcePostUrl } );
 			}
 			return post;
 		};
@@ -39,14 +39,14 @@ export function BlogPostFlow() {
 				await playgroundClient.goTo( post.link );
 			} )
 			.catch( ( err ) => console.error( err ) );
-	}, [ postUrl, apiClient ] );
+	}, [ sourcePostUrl, apiClient, playgroundClient ] );
 
 	return (
 		<>
 			{ currentStep !== Steps.start ? null : (
 				<Start
 					onExit={ ( url: string ) => {
-						setPostUrl( url );
+						setSourcePostUrl( url );
 						setCurrentStep(
 							! apiClient ? Steps.loading : Steps.selectContent
 						);

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Start } from '@/ui/flows/blog-post/Start';
 import { SelectContent } from '@/ui/flows/blog-post/SelectContent';
 import { Finish } from '@/ui/flows/blog-post/Finish';
 import { useSessionContext } from '@/ui/session/SessionProvider';
+import { Post } from '@/api/Post';
 
 enum Steps {
 	start = 1,
@@ -20,6 +21,25 @@ export function BlogPostFlow() {
 	if ( currentStep === Steps.loading && postUrl && !! apiClient ) {
 		setCurrentStep( Steps.selectContent );
 	}
+
+	// Get existing post from the API, or create a new one.
+	useEffect( () => {
+		if ( ! postUrl || ! apiClient ) {
+			return;
+		}
+		const getOrCreatePost = async (): Promise< Post > => {
+			let post = await apiClient.getPostByGuid( postUrl );
+			if ( ! post ) {
+				post = await apiClient.createPost( { guid: postUrl } );
+			}
+			return post;
+		};
+		getOrCreatePost()
+			.then( ( post: Post ) => {
+				console.log( post );
+			} )
+			.catch( ( err ) => console.error( err ) );
+	}, [ postUrl, apiClient ] );
 
 	return (
 		<>

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -15,7 +15,12 @@ export function BlogPostFlow() {
 	return (
 		<>
 			{ currentStep !== Steps.start ? null : (
-				<Start onExit={ () => setCurrentStep( Steps.selectContent ) } />
+				<Start
+					onExit={ ( postUrl: string ) => {
+						console.log( postUrl );
+						setCurrentStep( Steps.selectContent );
+					} }
+				/>
 			) }
 			{ currentStep !== Steps.selectContent ? null : (
 				<SelectContent

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -18,11 +18,6 @@ export function BlogPostFlow() {
 	const [ post, setPost ] = useState< Post >();
 	const { apiClient, playgroundClient } = useSessionContext();
 
-	// Proceed from loading screen once the apiClient is ready.
-	if ( currentStep === Steps.loading && sourcePostUrl && !! apiClient ) {
-		setCurrentStep( Steps.selectContent );
-	}
-
 	// Get existing post from the API, or create a new one.
 	// Once we have the post, make playground navigate to it.
 	useEffect( () => {
@@ -38,8 +33,9 @@ export function BlogPostFlow() {
 		};
 		getOrCreatePost()
 			.then( async ( p: Post ) => {
-				setPost( p );
 				void playgroundClient.goTo( p.link );
+				setPost( p );
+				setCurrentStep( Steps.selectContent );
 			} )
 			.catch( ( err ) => console.error( err ) );
 	}, [ sourcePostUrl, apiClient, playgroundClient ] );
@@ -50,15 +46,14 @@ export function BlogPostFlow() {
 				<Start
 					onExit={ ( url: string ) => {
 						setSourcePostUrl( url );
-						setCurrentStep(
-							! apiClient ? Steps.loading : Steps.selectContent
-						);
+						setCurrentStep( Steps.loading );
 					} }
 				/>
 			) }
 			{ currentStep !== Steps.loading ? null : <div>Loading...</div> }
-			{ currentStep !== Steps.selectContent ? null : (
+			{ currentStep !== Steps.selectContent || ! post ? null : (
 				<SelectContent
+					post={ post }
 					onExit={ () => setCurrentStep( Steps.finish ) }
 				/>
 			) }

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -2,26 +2,38 @@ import { useState } from 'react';
 import { Start } from '@/ui/flows/blog-post/Start';
 import { SelectContent } from '@/ui/flows/blog-post/SelectContent';
 import { Finish } from '@/ui/flows/blog-post/Finish';
+import { useSessionContext } from '@/ui/session/SessionProvider';
 
 enum Steps {
 	start = 1,
+	loading,
 	selectContent,
 	finish,
 }
 
 export function BlogPostFlow() {
 	const [ currentStep, setCurrentStep ] = useState( Steps.start );
+	const [ postUrl, setPostUrl ] = useState< string >();
+	const { apiClient } = useSessionContext();
+
+	// Proceed from loading screen once the apiClient is ready.
+	if ( currentStep === Steps.loading && postUrl && !! apiClient ) {
+		setCurrentStep( Steps.selectContent );
+	}
 
 	return (
 		<>
 			{ currentStep !== Steps.start ? null : (
 				<Start
-					onExit={ ( postUrl: string ) => {
-						console.log( postUrl );
-						setCurrentStep( Steps.selectContent );
+					onExit={ ( url: string ) => {
+						setPostUrl( url );
+						setCurrentStep(
+							! apiClient ? Steps.loading : Steps.selectContent
+						);
 					} }
 				/>
 			) }
+			{ currentStep !== Steps.loading ? null : <div>Loading...</div> }
 			{ currentStep !== Steps.selectContent ? null : (
 				<SelectContent
 					onExit={ () => setCurrentStep( Steps.finish ) }

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -15,6 +15,7 @@ enum Steps {
 export function BlogPostFlow() {
 	const [ currentStep, setCurrentStep ] = useState( Steps.start );
 	const [ sourcePostUrl, setSourcePostUrl ] = useState< string >();
+	const [ post, setPost ] = useState< Post >();
 	const { apiClient, playgroundClient } = useSessionContext();
 
 	// Proceed from loading screen once the apiClient is ready.
@@ -23,20 +24,22 @@ export function BlogPostFlow() {
 	}
 
 	// Get existing post from the API, or create a new one.
+	// Once we have the post, make playground navigate to it.
 	useEffect( () => {
 		if ( ! sourcePostUrl || ! apiClient ) {
 			return;
 		}
 		const getOrCreatePost = async (): Promise< Post > => {
-			let post = await apiClient.getPostByGuid( sourcePostUrl );
-			if ( ! post ) {
-				post = await apiClient.createPost( { guid: sourcePostUrl } );
+			let p = await apiClient.getPostByGuid( sourcePostUrl );
+			if ( ! p ) {
+				p = await apiClient.createPost( { guid: sourcePostUrl } );
 			}
-			return post;
+			return p;
 		};
 		getOrCreatePost()
-			.then( async ( post: Post ) => {
-				await playgroundClient.goTo( post.link );
+			.then( async ( p: Post ) => {
+				setPost( p );
+				void playgroundClient.goTo( p.link );
 			} )
 			.catch( ( err ) => console.error( err ) );
 	}, [ sourcePostUrl, apiClient, playgroundClient ] );

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -3,6 +3,7 @@ import { AppBus } from '@/bus/AppBus';
 import { Message } from '@/bus/Message';
 import { ContentBus } from '@/bus/ContentBus';
 import { cleanHtml } from '@/parser/cleanHtml';
+import { Post } from '@/api/Post';
 
 enum section {
 	title = 1,
@@ -15,7 +16,7 @@ interface SectionContent {
 	cleanHtml: string;
 }
 
-export function SelectContent( props: { onExit: () => void } ) {
+export function SelectContent( props: { post: Post; onExit: () => void } ) {
 	const { onExit } = props;
 	const [ title, setTitle ] = useState< SectionContent >();
 	const [ content, setContent ] = useState< SectionContent >();

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -26,6 +26,7 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 		section | false
 	>( false );
 
+	// Listen to click events coming from the content script.
 	useEffect( () => {
 		AppBus.listen( async ( message: Message ) => {
 			switch ( message.action ) {
@@ -40,7 +41,12 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 		};
 	}, [] );
 
-	if ( lastClickedElement ) {
+	// Handle a click on an event in the content script,
+	// according to which section is currently waiting for selection.
+	useEffect( () => {
+		if ( ! lastClickedElement ) {
+			return;
+		}
 		const original = lastClickedElement;
 		const clean = cleanHtml( original );
 
@@ -66,10 +72,9 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 		}
 		setWaitingForSelection( false );
 		setLastClickedElement( undefined );
-	}
+	}, [ waitingForSelection, lastClickedElement ] );
 
 	const isValid = title && date && content;
-
 	return (
 		<>
 			<div>Select the content of the post</div>

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -77,16 +77,21 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 	}, [ waitingForSelection, lastClickedElement ] );
 
 	// Save the post when selections happen.
-	useEffect( () => {
-		if ( ! title ) {
-			return;
-		}
-		apiClient
-			?.updatePost( post.id, {
-				title: title.cleanHtml ?? post.title.raw ?? '',
-			} )
-			.then( () => playgroundClient.goTo( post.link ) );
-	}, [ title ] );
+	useEffect(
+		() => {
+			if ( ! title ) {
+				return;
+			}
+			apiClient
+				?.updatePost( post.id, {
+					title: title.cleanHtml ?? post.title.raw ?? '',
+				} )
+				.then( () => playgroundClient.goTo( post.link ) );
+		},
+		// The dependencies are correct, we only want to trigger it when the title changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ title ]
+	);
 
 	const isValid = title && date && content;
 	return (

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -90,7 +90,8 @@ export function SelectContent( props: { onExit: () => void } ) {
 					!! waitingForSelection &&
 					waitingForSelection === section.title
 				}
-				onWaitingForSelection={ ( isWaiting ) => {
+				onWaitingForSelection={ async ( isWaiting ) => {
+					await ContentBus.enableHighlighting();
 					setWaitingForSelection( isWaiting ? section.title : false );
 				} }
 			/>
@@ -102,7 +103,8 @@ export function SelectContent( props: { onExit: () => void } ) {
 					!! waitingForSelection &&
 					waitingForSelection === section.date
 				}
-				onWaitingForSelection={ ( isWaiting ) => {
+				onWaitingForSelection={ async ( isWaiting ) => {
+					await ContentBus.enableHighlighting();
 					setWaitingForSelection( isWaiting ? section.date : false );
 				} }
 			/>
@@ -114,7 +116,8 @@ export function SelectContent( props: { onExit: () => void } ) {
 					!! waitingForSelection &&
 					waitingForSelection === section.content
 				}
-				onWaitingForSelection={ ( isWaiting ) => {
+				onWaitingForSelection={ async ( isWaiting ) => {
+					await ContentBus.enableHighlighting();
 					setWaitingForSelection(
 						isWaiting ? section.content : false
 					);

--- a/src/ui/flows/blog-post/Start.tsx
+++ b/src/ui/flows/blog-post/Start.tsx
@@ -10,7 +10,6 @@ export function Start( props: { onExit: ( postUrl: string ) => void } ) {
 			<button
 				onClick={ async () => {
 					const postUrl = await ContentBus.getCurrentUrl();
-					await ContentBus.enableHighlighting();
 					onExit( postUrl );
 				} }
 			>

--- a/src/ui/flows/blog-post/Start.tsx
+++ b/src/ui/flows/blog-post/Start.tsx
@@ -1,6 +1,6 @@
 import { ContentBus } from '@/bus/ContentBus';
 
-export function Start( props: { onExit: () => void } ) {
+export function Start( props: { onExit: ( postUrl: string ) => void } ) {
 	const { onExit } = props;
 	return (
 		<>
@@ -9,8 +9,9 @@ export function Start( props: { onExit: () => void } ) {
 			</div>
 			<button
 				onClick={ async () => {
+					const postUrl = await ContentBus.getCurrentUrl();
 					await ContentBus.enableHighlighting();
-					onExit();
+					onExit( postUrl );
 				} }
 			>
 				Continue

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -5,14 +5,13 @@ import {
 	startPlaygroundWeb,
 	StepDefinition,
 } from '@wp-playground/client';
-import { ApiClient } from '@/api/ApiClient';
 
 const playgroundIframeId = 'playground';
 
 export function Playground( props: {
 	slug: string;
 	className?: string;
-	onReady: ( apiClient: ApiClient ) => void;
+	onReady: ( client: PlaygroundClient ) => void;
 } ) {
 	const { slug, className, onReady } = props;
 
@@ -27,16 +26,10 @@ export function Playground( props: {
 		}
 
 		initPlayground( iframe, slug )
-			.then( async ( playgroundClient: PlaygroundClient ) => {
-				const apiClient = new ApiClient(
-					playgroundClient,
-					await playgroundClient.absoluteUrl
-				);
-				console.log(
-					'Playground communication established!',
-					apiClient.siteUrl
-				);
-				onReady( apiClient );
+			.then( async ( client: PlaygroundClient ) => {
+				const url = await client.absoluteUrl;
+				console.log( 'Playground communication established', url );
+				onReady( client );
 			} )
 			.catch( ( error ) => {
 				throw error;

--- a/src/ui/preview/Preview.tsx
+++ b/src/ui/preview/Preview.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react';
 import { PreviewTabBar } from '@/ui/preview/PreviewTabBar';
 import { Playground } from '@/ui/preview/Playground';
 import { useSessionContext } from '@/ui/session/SessionProvider';
-import { ApiClient } from '@/api/ApiClient';
+import { PlaygroundClient } from '@wp-playground/client';
 
 const tabFront = 0;
 const tabAdmin = 1;
 const defaultTab = tabFront;
 
 export function Preview( props: {
-	onReady: ( apiClient: ApiClient ) => void;
+	onReady: ( playgroundClient: PlaygroundClient ) => void;
 } ) {
 	const { onReady } = props;
 	const [ currentTab, setCurrentTab ] = useState< number >( defaultTab );

--- a/src/ui/session/SessionProvider.ts
+++ b/src/ui/session/SessionProvider.ts
@@ -1,10 +1,12 @@
 import { createContext, useContext } from 'react';
 import { Session } from '@/storage/session';
 import { ApiClient } from '@/api/ApiClient';
+import { PlaygroundClient } from '@wp-playground/client';
 
 export interface SessionContext {
 	session: Session;
 	apiClient?: ApiClient;
+	playgroundClient?: PlaygroundClient;
 }
 
 const sessionContext = createContext< SessionContext >( {


### PR DESCRIPTION
This PR iterates on the blog post flow.

Note that the API calls are not correct yet, this PR just does the minimum so that the flow is in place, I will make the correct API calls in the next PR. This means that currently, the preview does not show the title the user selected, for example, it just shows an empty post page.

## Summary of changes

- Make it possible to ask the content script what the current URL is
- Make it possible to make POST requests to the API, through the `createPost()` and `updatePost()` methods of `ApiClient`. These methods are not fully implemented yet, I will do so in the next PR.
- Add `PlaygroundClient` to the session context, so that it's available everywhere.
- Call the WP REST API at the start of the Import Blog flow, to create an empty post.
- Make Playground automatically navigate to the page of said post.
- As the user selects elements (title, date, etc), we make requests to the API to update the post, and refresh the page in playground. (this is not visible yet as the API calls are not correct).

## Screen capture

> Note how Playground navigates to the page of the post.


https://github.com/user-attachments/assets/0670a8e6-5ac4-43f1-ac29-851cee8569d8


