### PR TITLE
Inspection UI: Pass 1

### DIFF
--- a/src/plugin/class-post-type-manager.php
+++ b/src/plugin/class-post-type-manager.php
@@ -24,7 +24,7 @@ class Post_Type_Manager {
 		add_action( 'init', array( $this, 'register_post_types' ) );
 	}
 
-	private function is_local_env(): bool {
+	private function should_show_ui(): bool {
 		return wp_get_environment_type() === 'local';
 	}
 
@@ -54,8 +54,8 @@ class Post_Type_Manager {
 			'exclude_from_search' => true,
 			'publicly_queryable'  => true,
 			'show_in_rest'        => true,
-			'show_ui'             => $this->is_local_env(),
-			'show_in_menu'        => $this->is_local_env(),
+			'show_ui'             => $this->should_show_ui(),
+			'show_in_menu'        => $this->should_show_ui(),
 			'supports'            => $this->custom_post_types_supports,
 		);
 

--- a/src/plugin/class-post-type-manager.php
+++ b/src/plugin/class-post-type-manager.php
@@ -24,6 +24,10 @@ class Post_Type_Manager {
 		add_action( 'init', array( $this, 'register_post_types' ) );
 	}
 
+	private function is_local_env(): bool {
+		return wp_get_environment_type() === 'local';
+	}
+
 	/**
 	 * This function collects values of all constants defined as POST_TYPE_ in an array.
 	 * Useful to declare multiple meta-fields on each one of them.
@@ -50,8 +54,8 @@ class Post_Type_Manager {
 			'exclude_from_search' => true,
 			'publicly_queryable'  => true,
 			'show_in_rest'        => true,
-			'show_ui'             => false,
-			'show_in_menu'        => false,
+			'show_ui'             => $this->is_local_env(),
+			'show_in_menu'        => $this->is_local_env(),
 			'supports'            => $this->custom_post_types_supports,
 		);
 

--- a/src/plugin/class-post-type-ui.php
+++ b/src/plugin/class-post-type-ui.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+class Post_Type_UI {
+	private array $post_types;
+
+	public function __construct( $post_types ) {
+		$this->post_types = $post_types;
+
+		// Strip editor to be barebones.
+		add_filter(
+			'wp_editor_settings',
+			function ( $settings, $editor_id ) {
+				if ( 'content' === $editor_id && in_array( get_current_screen()->post_type, $this->post_types, true ) ) {
+					$settings['tinymce']       = false;
+					$settings['quicktags']     = false;
+					$settings['media_buttons'] = false;
+				}
+
+				return $settings;
+			},
+			10,
+			2
+		);
+
+		// Disable "Add media" button.
+		add_action(
+			'admin_head',
+			function () {
+				global $pagenow;
+
+				$cpt_screen = false;
+				if ( 'post-new.php' === $pagenow ) { // New post screen
+					// @phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					if ( isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $this->post_types, true ) ) {
+						$cpt_screen = true;
+					}
+				}
+
+				if ( 'post.php' === $pagenow ) { // Edit post screen
+					// @phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+					$post_type = get_post_type( absint( $_GET['post'] ) );
+					if ( in_array( $post_type, $this->post_types, true ) ) {
+						$cpt_screen = true;
+					}
+				}
+
+				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+				if ( $cpt_screen ) {
+					// CPT screen-specific filters go here.
+				}
+			}
+		);
+
+		// Disable Block editor.
+		add_filter(
+			'use_block_editor_for_post_type',
+			function ( $use_block_editor, $post_type ) {
+				if ( in_array( $post_type, $this->post_types, true ) ) {
+					return false;
+				}
+
+				return $use_block_editor;
+			},
+			10,
+			2
+		);
+
+		// Remove meta boxes.
+		add_action(
+			'add_meta_boxes',
+			function () {
+				foreach ( $this->post_types as $post_type ) {
+					// Remove default meta boxes
+					remove_meta_box( 'submitdiv', $post_type, 'side' );
+					remove_meta_box( 'slugdiv', $post_type, 'normal' );
+					/**
+					 * We would need to remove more metaboxes as their support is added to CPTs.
+					 * Leaving code here for reference.
+					 */
+					// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+					// remove_meta_box( 'postexcerpt', $post_type, 'normal' );
+					// remove_meta_box( 'authordiv', $post_type, 'normal' );
+					// remove_meta_box( 'categorydiv', $post_type, 'side' );
+					// remove_meta_box( 'tagsdiv-post_tag', $post_type, 'side' );
+					// remove_meta_box( 'postimagediv', $post_type, 'side' );
+					// remove_meta_box( 'revisionsdiv', $post_type, 'normal' );
+					// remove_meta_box( 'commentstatusdiv', $post_type, 'normal' );
+					// remove_meta_box( 'commentsdiv', $post_type, 'normal' );
+					// remove_meta_box( 'trackbacksdiv', $post_type, 'normal' );
+				}
+			},
+			999
+		);
+	}
+}

--- a/src/plugin/plugin.php
+++ b/src/plugin/plugin.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require 'class-post-type-manager.php';
+require 'class-post-type-ui.php';
 require 'class-meta-fields-manager.php';
 require 'class-rest-api-extender.php';
 
@@ -20,6 +21,7 @@ require 'class-rest-api-extender.php';
 	$post_type_manager = new Post_Type_Manager();
 	$custom_post_types = $post_type_manager->get_custom_post_types();
 
+	new Post_Type_UI( $custom_post_types );
 	new Meta_Fields_Manager( $custom_post_types );
 	new Rest_API_Extender( $custom_post_types );
 } )();


### PR DESCRIPTION
This PR strips the CPTs admin pages to be barebones to just show data. Currently we show: title, post content, meta fields

Before | After
:-------------------------:|:-------------------------:
<img width="1280" alt="Screenshot 2024-09-23 at 17 54 38" src="https://github.com/user-attachments/assets/f99db409-c3e4-4197-a233-360a4b80aa52">  |  <img width="1279" alt="Screenshot 2024-09-23 at 17 57 19" src="https://github.com/user-attachments/assets/3d20eda6-7d45-4751-9b69-3dbac8066e8a">

I would follow up with more PRs to tune them so that they are useful as I discover our tooling needs after saving some real world data.




