### PR TITLE
Inspection UI: Pass 3 (Promoted post meta box)

### DIFF
--- a/src/plugin/class-post-type-ui.php
+++ b/src/plugin/class-post-type-ui.php
@@ -4,9 +4,11 @@ namespace DotOrg\TryWordPress;
 
 class Post_Type_UI {
 	private array $post_types;
+	private Promoter $promoter;
 
-	public function __construct( $post_types ) {
+	public function __construct( $post_types, Promoter $promoter ) {
 		$this->post_types = $post_types;
+		$this->promoter   = $promoter;
 
 		// Strip editor to be barebones.
 		add_filter(
@@ -97,7 +99,7 @@ class Post_Type_UI {
 							global $post;
 
 							$post_id          = $post->ID;
-							$promoted_post_id = get_post_meta( $post_id, '_promoted_post', true );
+							$promoted_post_id = $this->promoter->get_promoted_post( $post_id );
 
 							if ( $promoted_post_id ) {
 								echo '<pre>PostID: ' . esc_html( $promoted_post_id ) . '</pre>';

--- a/src/plugin/class-post-type-ui.php
+++ b/src/plugin/class-post-type-ui.php
@@ -24,7 +24,7 @@ class Post_Type_UI {
 			2
 		);
 
-		// Disable "Add media" button.
+		// CPT screen-specific filters
 		add_action(
 			'admin_head',
 			function () {
@@ -89,6 +89,34 @@ class Post_Type_UI {
 					// remove_meta_box( 'commentstatusdiv', $post_type, 'normal' );
 					// remove_meta_box( 'commentsdiv', $post_type, 'normal' );
 					// remove_meta_box( 'trackbacksdiv', $post_type, 'normal' );
+
+					add_meta_box(
+						'promotedpost',
+						'Promoted To',
+						function () {
+							global $post;
+
+							$post_id          = $post->ID;
+							$promoted_post_id = get_post_meta( $post_id, '_promoted_post', true );
+
+							if ( $promoted_post_id ) {
+								echo '<pre>PostID: ' . esc_html( $promoted_post_id ) . '</pre>';
+								$preview_link = get_permalink( $promoted_post_id );
+								$edit_link    = get_edit_post_link( $promoted_post_id );
+								?>
+								<p>
+									<a href="<?php echo esc_url( $preview_link ); ?>" target="_blank">Preview Post</a> |
+									<a href="<?php echo esc_url( $edit_link ); ?>">Edit Post</a>
+								</p>
+								<?php
+							} else {
+								echo "<p>This post hasn't been promoted yet.</p>";
+							}
+						},
+						$post_type,
+						'side',
+						'default'
+					);
 				}
 			},
 			999

--- a/src/plugin/class-post-type-ui.php
+++ b/src/plugin/class-post-type-ui.php
@@ -99,7 +99,7 @@ class Post_Type_UI {
 							global $post;
 
 							$post_id          = $post->ID;
-							$promoted_post_id = $this->promoter->get_promoted_post( $post_id );
+							$promoted_post_id = $this->promoter->get_promoted_post_id( $post_id );
 
 							if ( $promoted_post_id ) {
 								echo '<pre>PostID: ' . esc_html( $promoted_post_id ) . '</pre>';

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -13,8 +13,13 @@ class Promoter {
 		return str_replace( 'liberated_', '', $post_type );
 	}
 
-	public function get_promoted_post_id( $liberated_post_id ): int {
-		return absint( get_post_meta( $liberated_post_id, $this->meta_key_for_promoted_post, true ) );
+	public function get_promoted_post_id( $liberated_post_id ): int|null {
+		$value = get_post_meta( $liberated_post_id, $this->meta_key_for_promoted_post, true );
+		if ( '' === $value ) {
+			return null;
+		}
+
+		return absint( $value );
 	}
 
 	/**

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use WP_Post;
+
+class Promoter {
+	private string $meta_key_for_promoted_post = '_promoted_post';
+
+	public function __construct() {}
+
+	private function get_post_type_for_promoted_post( string $post_type ): string {
+		return str_replace( 'liberated_', '', $post_type );
+	}
+
+	public function get_promoted_post( $liberated_post_id ): int {
+		return absint( get_post_meta( $liberated_post_id, $this->meta_key_for_promoted_post, true ) );
+	}
+
+	/**
+	 * This function copies over the liberated_* custom post types to its destined post type.
+	 *
+	 * @param int|WP_Post $liberated_post Post id or Post object.
+	 * @return bool
+	 */
+	public function promote( int|WP_Post $liberated_post ): bool {
+		if ( is_int( $liberated_post ) ) {
+			$liberated_post = get_post( $liberated_post );
+		}
+
+		$inserted_post_id = wp_insert_post(
+			array(
+				'post_author'       => $liberated_post->post_author,
+				'post_date'         => $liberated_post->post_date,
+				'post_date_gmt'     => $liberated_post->post_date_gmt,
+				'post_modified'     => $liberated_post->post_modified,
+				'post_modified_gmt' => $liberated_post->post_modified_gmt,
+				'post_content'      => $liberated_post->post_content,
+				'post_title'        => $liberated_post->post_title,
+				'post_excerpt'      => $liberated_post->post_excerpt,
+				'post_status'       => 'publish',
+				'comment_status'    => $liberated_post->comment_status,
+				'ping_status'       => $liberated_post->ping_status,
+				'post_password'     => $liberated_post->post_password,
+				'post_name'         => $liberated_post->post_name,
+				'post_type'         => $this->get_post_type_for_promoted_post( $liberated_post->post_type ),
+			)
+		);
+
+		// @TODO: handle attachments, terms etc in future
+		// Note: Do not need anything from postmeta.
+		// We should potentially use another plugin here for this purpose and call its API to do it for us.
+
+		if ( is_wp_error( $inserted_post_id ) ) {
+			return false;
+		}
+
+		add_post_meta( $liberated_post->ID, $this->meta_key_for_promoted_post, $inserted_post_id );
+		return true;
+	}
+}

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -13,7 +13,7 @@ class Promoter {
 		return str_replace( 'liberated_', '', $post_type );
 	}
 
-	public function get_promoted_post( $liberated_post_id ): int {
+	public function get_promoted_post_id( $liberated_post_id ): int {
 		return absint( get_post_meta( $liberated_post_id, $this->meta_key_for_promoted_post, true ) );
 	}
 

--- a/src/plugin/class-rest-api-extender.php
+++ b/src/plugin/class-rest-api-extender.php
@@ -8,9 +8,11 @@ use WP_Error;
 
 class Rest_API_Extender {
 	private array $custom_post_types;
+	private Promoter $promoter;
 
-	public function __construct( $custom_post_types ) {
+	public function __construct( $custom_post_types, $promoter ) {
 		$this->custom_post_types = $custom_post_types;
+		$this->promoter          = $promoter;
 
 		add_action( 'rest_api_init', array( $this, 'register_route' ) );
 
@@ -51,54 +53,22 @@ class Rest_API_Extender {
 		$post_id = $request['id'];
 		$post    = get_post( $post_id );
 
-		if ( ! $post ) {
+		if ( is_null( $post ) ) {
 			return new WP_Error( 'no_post', 'Invalid post ID', array( 'status' => 404 ) );
 		}
 
-		if ( $this->promote_liberated_post_types( $post ) ) {
+		if ( $this->promoter->promote( $post ) ) {
 			return new WP_REST_Response(
 				array(
 					'success' => true,
 					'message' => 'Post promoted successfully',
-					'post_id' => get_post_meta( $post_id, '_liberated_post', true ),
+					'post_id' => $this->promoter->get_promoted_post( $post_id ),
 				),
 				200
 			);
 		} else {
 			return new WP_Error( 'error', 'Could not promote post', array( 'status' => 500 ) );
 		}
-	}
-
-	public function promote_liberated_post_types( $post ): bool {
-		$inserted_post_id = wp_insert_post(
-			array(
-				'post_author'       => $post->post_author,
-				'post_date'         => $post->post_date,
-				'post_date_gmt'     => $post->post_date_gmt,
-				'post_modified'     => $post->post_modified,
-				'post_modified_gmt' => $post->post_modified_gmt,
-				'post_content'      => $post->post_content,
-				'post_title'        => $post->post_title,
-				'post_excerpt'      => $post->post_excerpt,
-				'post_status'       => 'publish',
-				'comment_status'    => $post->comment_status,
-				'ping_status'       => $post->ping_status,
-				'post_password'     => $post->post_password,
-				'post_name'         => $post->post_name,
-				'post_type'         => str_replace( 'liberated_', '', $post->post_type ),
-			)
-		);
-
-		// @TODO: handle attachments, terms etc in future
-		// Note: Do not need anything from postmeta.
-		// We should potentially use another plugin here for this purpose and call its API to do it for us.
-
-		if ( is_wp_error( $inserted_post_id ) ) {
-			return false;
-		}
-
-		add_post_meta( $post->ID, '_liberated_post', $inserted_post_id );
-		return true;
 	}
 
 	public function filter_posts_by_guid( $post_type, $args, \WP_REST_Request $request ): array {

--- a/src/plugin/class-rest-api-extender.php
+++ b/src/plugin/class-rest-api-extender.php
@@ -62,7 +62,7 @@ class Rest_API_Extender {
 				array(
 					'success' => true,
 					'message' => 'Post promoted successfully',
-					'post_id' => $this->promoter->get_promoted_post( $post_id ),
+					'post_id' => $this->promoter->get_promoted_post_id( $post_id ),
 				),
 				200
 			);

--- a/src/plugin/plugin.php
+++ b/src/plugin/plugin.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require 'class-post-type-manager.php';
 require 'class-post-type-ui.php';
+require 'class-promoter.php';
 require 'class-meta-fields-manager.php';
 require 'class-rest-api-extender.php';
 
@@ -23,5 +24,6 @@ require 'class-rest-api-extender.php';
 
 	new Post_Type_UI( $custom_post_types );
 	new Meta_Fields_Manager( $custom_post_types );
-	new Rest_API_Extender( $custom_post_types );
+
+	new Rest_API_Extender( $custom_post_types, new Promoter() );
 } )();

--- a/src/plugin/plugin.php
+++ b/src/plugin/plugin.php
@@ -22,8 +22,10 @@ require 'class-rest-api-extender.php';
 	$post_type_manager = new Post_Type_Manager();
 	$custom_post_types = $post_type_manager->get_custom_post_types();
 
-	new Post_Type_UI( $custom_post_types );
+	$promoter = new Promoter();
+
+	new Post_Type_UI( $custom_post_types, $promoter );
 	new Meta_Fields_Manager( $custom_post_types );
 
-	new Rest_API_Extender( $custom_post_types, new Promoter() );
+	new Rest_API_Extender( $custom_post_types, $promoter );
 } )();

--- a/tests/plugin/test-meta-fields-manager.php
+++ b/tests/plugin/test-meta-fields-manager.php
@@ -49,9 +49,9 @@ class Meta_Fields_Manager_Test extends TestCase {
 		);
 	}
 
-	public function testMoveMeteFields() {
-		$prepared_post = new \stdClass();
-		$request       = $this->createMock( \WP_REST_Request::class );
+	public function testMoveMetaFields() {
+		$prepared_post = new stdClass();
+		$request       = $this->createMock( WP_REST_Request::class );
 
 		$initial_meta = array(
 			'guid'        => 'test-guid',
@@ -84,10 +84,10 @@ class Meta_Fields_Manager_Test extends TestCase {
 	}
 
 	public function testPrepareMetaFields() {
-		$request  = $this->createMock( \WP_REST_Request::class );
-		$response = $this->createMock( \WP_REST_Response::class );
+		$request  = $this->createMock( WP_REST_Request::class );
+		$response = $this->createMock( WP_REST_Response::class );
 
-		$post                        = new \stdClass();
+		$post                        = new stdClass();
 		$post->guid                  = 'test-guid';
 		$post->post_content_filtered = 'test-content';
 

--- a/tests/plugin/test-nothing.php
+++ b/tests/plugin/test-nothing.php
@@ -1,9 +1,0 @@
-<?php
-
-use PHPUnit\Framework\TestCase;
-
-class MockNada extends TestCase {
-	public function test_nothing() {
-		$this->assertTrue( true );
-	}
-}

--- a/tests/plugin/test-promoter.php
+++ b/tests/plugin/test-promoter.php
@@ -31,7 +31,7 @@ class Promoter_Test extends TestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 
-		$promoted_post_id = $this->promoter->get_promoted_post( $this->post_id_in_db );
+		$promoted_post_id = $this->promoter->get_promoted_post_id( $this->post_id_in_db );
 		wp_delete_post( $promoted_post_id, true );
 		wp_delete_post( $this->post_id_in_db, true );
 	}
@@ -49,7 +49,7 @@ class Promoter_Test extends TestCase {
 	public function testGetPromotedPost() {
 		add_post_meta( 99, '_promoted_post', 999 );
 
-		$this->assertEquals( 999, $this->promoter->get_promoted_post( 99 ) );
+		$this->assertEquals( 999, $this->promoter->get_promoted_post_id( 99 ) );
 	}
 
 	public function testPromote(): void {

--- a/tests/plugin/test-promoter.php
+++ b/tests/plugin/test-promoter.php
@@ -50,6 +50,7 @@ class Promoter_Test extends TestCase {
 		add_post_meta( 99, '_promoted_post', 999 );
 
 		$this->assertEquals( 999, $this->promoter->get_promoted_post_id( 99 ) );
+		$this->assertEquals( null, $this->promoter->get_promoted_post_id( 88 ) );
 	}
 
 	public function testPromote(): void {


### PR DESCRIPTION
This PR adds a promoted post details meta box on edit screen.

<img width="1728" alt="Screenshot 2024-09-24 at 16 03 50" src="https://github.com/user-attachments/assets/7612eefc-c7f6-4cc8-a71d-e653edcf8c42">

<img width="373" alt="Screenshot 2024-09-24 at 16 04 33" src="https://github.com/user-attachments/assets/6d32998c-caa6-49b2-aee5-6cbcb926e4e0">

In order to do so, I extracted out the promote functionality into its own class to prevent the meta key spread across diff files. This also sets the foundation for handling complicated steps in promotion later on. Tests adjusted accordingly with some minor enhancements.