### PR TITLE
Fetch existing post

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -49,7 +49,7 @@ export class ApiClient {
 			method: 'GET',
 		} );
 		if ( response.httpStatusCode !== 200 ) {
-			console.error( response, response.json );
+			console.error( response, params, response.json );
 			throw Error( response.json.message );
 		}
 		return response.json;
@@ -66,7 +66,7 @@ export class ApiClient {
 		} );
 
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
-			console.error( response, response.json );
+			console.error( response, body, response.json );
 			throw Error( response.json.message );
 		}
 		return response.json;

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -35,9 +35,17 @@ export class ApiClient {
 		return this._users;
 	}
 
-	async get( route: string ): Promise< object > {
+	async get(
+		route: string,
+		params?: Record< string, string >
+	): Promise< object > {
+		let url = `/index.php?rest_route=/wp/v2${ route }`;
+		for ( const name in params ) {
+			const encoded = encodeURIComponent( params[ name ] );
+			url += `&${ name }=${ encoded }`;
+		}
 		const response = await this.playgroundClient.request( {
-			url: `/index.php?rest_route=/wp/v2${ route }`,
+			url,
 			method: 'GET',
 		} );
 		if ( response.httpStatusCode !== 200 ) {

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -41,7 +41,7 @@ export class ApiClient {
 			method: 'GET',
 		} );
 		if ( response.httpStatusCode !== 200 ) {
-			console.error( response );
+			console.error( response, response.json );
 			throw Error( response.json.message );
 		}
 		return response.json;
@@ -58,7 +58,7 @@ export class ApiClient {
 		} );
 
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
-			console.error( response );
+			console.error( response, response.json );
 			throw Error( response.json.message );
 		}
 		return response.json;

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -60,15 +60,25 @@ export class PostsApi {
 		return makePostFromApiResponse( response );
 	}
 
-	async getByGuid( guid: string ): Promise< Post | null > {
-		const posts = ( await this.client.get( `/liberated_posts`, {
-			context: 'edit',
-			status: 'draft',
-			guid,
-		} ) ) as ApiPost[];
+	async findByGuid( guid: string ): Promise< Post | null > {
+		// eslint-disable-next-line react/no-is-mounted
+		const posts = await this.find( { guid } );
 		return posts.length === 0
 			? null
 			: makePostFromApiResponse( posts[ 0 ] );
+	}
+
+	private async find(
+		params: Record< string, string >
+	): Promise< ApiPost[] > {
+		// A liberated_post is always draft.
+		params.status = 'draft';
+		// Must set context to 'edit' to have all fields in the response.
+		params.context = 'edit';
+		return ( await this.client.get(
+			`/liberated_posts`,
+			params
+		) ) as ApiPost[];
 	}
 }
 

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -60,9 +60,14 @@ export class PostsApi {
 		return makePostFromApiResponse( response );
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async getByGuid( guid: string ): Promise< Post | null > {
-		return null;
+		const posts = ( await this.client.get( `/liberated_posts`, {
+			status: 'draft',
+			guid,
+		} ) ) as ApiPost[];
+		return posts.length === 0
+			? null
+			: makePostFromApiResponse( posts[ 0 ] );
 	}
 }
 

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -37,7 +37,10 @@ export class PostsApi {
 	}
 
 	async update( id: number, body: UpdateBody ): Promise< Post > {
-		const actualBody: any = { meta: {} };
+		const actualBody: any = {};
+		if ( body.date || body.title || body.content ) {
+			actualBody.meta = {};
+		}
 		if ( body.date ) {
 			actualBody.date = body.date.parsed;
 			actualBody.meta.raw_date = body.date.original;

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -42,7 +42,7 @@ export class PostsApi {
 			actualBody.meta = {};
 		}
 		if ( body.date ) {
-			actualBody.date = body.date.parsed;
+			actualBody.date = body.date.utcString;
 			actualBody.meta.raw_date = body.date.original;
 		}
 		if ( body.title ) {

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -62,6 +62,7 @@ export class PostsApi {
 
 	async getByGuid( guid: string ): Promise< Post | null > {
 		const posts = ( await this.client.get( `/liberated_posts`, {
+			context: 'edit',
 			status: 'draft',
 			guid,
 		} ) ) as ApiPost[];
@@ -79,8 +80,6 @@ function makePostFromApiResponse( response: ApiPost ): Post {
 		meta.raw_content,
 		response.content.raw ?? ''
 	);
-
-	console.log( date, title, content );
 
 	return {
 		guid: meta.guid,

--- a/src/api/Posts.ts
+++ b/src/api/Posts.ts
@@ -37,18 +37,18 @@ export class PostsApi {
 	}
 
 	async update( id: number, body: UpdateBody ): Promise< Post > {
-		const actualBody: any = {};
+		const actualBody: any = { meta: {} };
 		if ( body.date ) {
 			actualBody.date = body.date.parsed;
+			actualBody.meta.raw_date = body.date.original;
 		}
 		if ( body.title ) {
 			actualBody.title = body.title.parsed;
+			actualBody.meta.raw_title = body.title.original;
 		}
 		if ( body.content ) {
 			actualBody.content = body.content.parsed;
-			actualBody.meta = {
-				raw_content: body.content.original,
-			};
+			actualBody.meta.raw_content = body.content.original;
 		}
 		if ( Object.keys( actualBody ).length === 0 ) {
 			throw Error( 'attempting to update zero fields' );
@@ -73,12 +73,14 @@ export class PostsApi {
 
 function makePostFromApiResponse( response: ApiPost ): Post {
 	const meta = response.meta as unknown as PostMeta;
-	const date = new PostDate( response.date_gmt, meta.raw_date );
-	const title = new PostTitle( response.title.raw ?? '', meta.raw_title );
+	const date = new PostDate( meta.raw_date, response.date_gmt );
+	const title = new PostTitle( meta.raw_title, response.title.raw ?? '' );
 	const content = new PostContent(
-		response.content.raw ?? '',
-		meta.raw_content
+		meta.raw_content,
+		response.content.raw ?? ''
 	);
+
+	console.log( date, title, content );
 
 	return {
 		guid: meta.guid,

--- a/src/model/Post.ts
+++ b/src/model/Post.ts
@@ -14,23 +14,31 @@ abstract class PostSection< T > {
 		this.original = original;
 		this.parsed = parsed;
 	}
-	abstract value(): T;
+	abstract get value(): T;
 }
 
 export class PostDate extends PostSection< Date > {
-	value(): Date {
-		return new Date( this.parsed );
+	readonly _value: Date;
+	constructor( original: string = '', parsed: string = '' ) {
+		super( original, parsed );
+		this._value = parsed === '' ? new Date() : new Date( this.parsed );
+	}
+	get value(): Date {
+		return this._value;
+	}
+	get utcString(): string {
+		return this._value.toISOString();
 	}
 }
 
 export class PostTitle extends PostSection< string > {
-	value(): string {
+	get value(): string {
 		return this.parsed;
 	}
 }
 
 export class PostContent extends PostSection< string > {
-	value(): string {
+	get value(): string {
 		return this.parsed;
 	}
 }

--- a/src/model/Post.ts
+++ b/src/model/Post.ts
@@ -10,7 +10,7 @@ export interface Post {
 abstract class PostSection< T > {
 	original: string;
 	parsed: string;
-	constructor( original: string, parsed: string ) {
+	constructor( original: string = '', parsed: string = '' ) {
 		this.original = original;
 		this.parsed = parsed;
 	}

--- a/src/plugin/class-rest-api-extender.php
+++ b/src/plugin/class-rest-api-extender.php
@@ -76,13 +76,15 @@ class Rest_API_Extender {
 			return $args;
 		}
 
+		$guid = urldecode( $request->get_param( 'guid' ) );
+
 		global $wpdb;
 		// @phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND guid = %s AND post_status IN ('draft', 'publish') LIMIT 1",
 				$post_type,
-				$request->get_param( 'guid' )
+				$guid
 			)
 		);
 

--- a/src/ui/flows/blog-post/BlogPostFlow.tsx
+++ b/src/ui/flows/blog-post/BlogPostFlow.tsx
@@ -25,7 +25,7 @@ export function BlogPostFlow() {
 			return;
 		}
 		const getOrCreatePost = async (): Promise< Post > => {
-			let p = await apiClient.posts.getByGuid( sourcePostUrl );
+			let p = await apiClient.posts.findByGuid( sourcePostUrl );
 			if ( ! p ) {
 				p = await apiClient.posts.create( { guid: sourcePostUrl } );
 			}

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -53,25 +53,27 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 				field: section | false,
 				value: string
 			): Promise< void > {
-				let p: Post;
 				switch ( field ) {
 					case section.date:
-						p = await apiClient!.posts.update( post.id, {
-							date: parsePostDate( value ),
+						const newDate = parsePostDate( value );
+						setDate( newDate );
+						await apiClient!.posts.update( post.id, {
+							date: newDate,
 						} );
-						setDate( p.date );
 						break;
 					case section.title:
-						p = await apiClient!.posts.update( post.id, {
-							title: parsePostTitle( value ),
+						const newTitle = parsePostTitle( value );
+						setTitle( newTitle );
+						await apiClient!.posts.update( post.id, {
+							title: newTitle,
 						} );
-						setTitle( p.title );
 						break;
 					case section.content:
-						p = await apiClient!.posts.update( post.id, {
-							content: parsePostContent( value ),
+						const newContent = parsePostContent( value );
+						setContent( newContent );
+						await apiClient!.posts.update( post.id, {
+							content: newContent,
 						} );
-						setContent( p.content );
 						break;
 					default:
 						throw Error( `unexpected field: ${ field }` );
@@ -116,11 +118,12 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 					setWaitingForSelection( isWaiting ? section.title : false );
 				} }
 				onClear={ async () => {
-					const p = await apiClient!.posts.update( post.id, {
-						title: new PostTitle(),
+					const newTitle = new PostTitle();
+					setTitle( newTitle );
+					await apiClient!.posts.update( post.id, {
+						title: newTitle,
 					} );
-					setTitle( p.title );
-					await playgroundClient.goTo( p.url );
+					await playgroundClient.goTo( post.url );
 				} }
 			/>
 			<Section
@@ -137,11 +140,12 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 					setWaitingForSelection( isWaiting ? section.date : false );
 				} }
 				onClear={ async () => {
-					const p = await apiClient!.posts.update( post.id, {
-						date: new PostDate(),
+					const newDate = new PostDate();
+					setDate( newDate );
+					await apiClient!.posts.update( post.id, {
+						date: newDate,
 					} );
-					setDate( p.date );
-					await playgroundClient.goTo( p.url );
+					await playgroundClient.goTo( post.url );
 				} }
 			/>
 			<Section
@@ -160,11 +164,12 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 					);
 				} }
 				onClear={ async () => {
-					const p = await apiClient!.posts.update( post.id, {
-						content: new PostContent(),
+					const newContent = new PostContent();
+					setContent( newContent );
+					await apiClient!.posts.update( post.id, {
+						content: newContent,
 					} );
-					setContent( p.content );
-					await playgroundClient.goTo( p.url );
+					await playgroundClient.goTo( post.url );
 				} }
 			/>
 		</>

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -14,9 +14,9 @@ enum section {
 
 export function SelectContent( props: { post: Post; onExit: () => void } ) {
 	const { post, onExit } = props;
-	const [ date, setDate ] = useState< PostDate >();
-	const [ title, setTitle ] = useState< PostTitle >();
-	const [ content, setContent ] = useState< PostContent >();
+	const [ date, setDate ] = useState< PostDate >( post.date );
+	const [ title, setTitle ] = useState< PostTitle >( post.title );
+	const [ content, setContent ] = useState< PostContent >( post.content );
 	const [ lastClickedElement, setLastClickedElement ] = useState< string >();
 	const [ waitingForSelection, setWaitingForSelection ] = useState<
 		section | false

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -115,6 +115,13 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 					await ContentBus.enableHighlighting();
 					setWaitingForSelection( isWaiting ? section.title : false );
 				} }
+				onClear={ async () => {
+					const p = await apiClient!.posts.update( post.id, {
+						title: new PostTitle(),
+					} );
+					setTitle( p.title );
+					await playgroundClient.goTo( p.url );
+				} }
 			/>
 			<Section
 				label="Date"
@@ -128,6 +135,13 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 				onWaitingForSelection={ async ( isWaiting ) => {
 					await ContentBus.enableHighlighting();
 					setWaitingForSelection( isWaiting ? section.date : false );
+				} }
+				onClear={ async () => {
+					const p = await apiClient!.posts.update( post.id, {
+						date: new PostDate(),
+					} );
+					setDate( p.date );
+					await playgroundClient.goTo( p.url );
 				} }
 			/>
 			<Section
@@ -145,6 +159,13 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 						isWaiting ? section.content : false
 					);
 				} }
+				onClear={ async () => {
+					const p = await apiClient!.posts.update( post.id, {
+						content: new PostContent(),
+					} );
+					setContent( p.content );
+					await playgroundClient.goTo( p.url );
+				} }
 			/>
 		</>
 	);
@@ -157,6 +178,7 @@ function Section( props: {
 	parsedValue: string | undefined;
 	waitingForSelection: boolean;
 	onWaitingForSelection: ( isWaiting: boolean ) => void;
+	onClear: () => void;
 } ) {
 	const {
 		label,
@@ -165,6 +187,7 @@ function Section( props: {
 		parsedValue,
 		waitingForSelection,
 		onWaitingForSelection,
+		onClear,
 	} = props;
 
 	return (
@@ -177,6 +200,12 @@ function Section( props: {
 		>
 			<div>
 				{ label }{ ' ' }
+				<button
+					disabled={ disabled || originalValue === '' }
+					onClick={ onClear }
+				>
+					Clear
+				</button>
 				<button
 					disabled={ disabled }
 					onClick={ async () => {

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -90,7 +90,11 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 		[ waitingForSelection, lastClickedElement ]
 	);
 
-	const isValid = title && date && content;
+	const isValid =
+		title.original !== '' &&
+		date.original !== '' &&
+		content.original !== '';
+
 	return (
 		<>
 			<div>Select the content of the post</div>
@@ -106,8 +110,8 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 			</button>
 			<Section
 				label="Title"
-				originalValue={ title?.original }
-				parsedValue={ title?.parsed }
+				originalValue={ title.original }
+				parsedValue={ title.parsed }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&
@@ -128,8 +132,8 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 			/>
 			<Section
 				label="Date"
-				originalValue={ date?.original }
-				parsedValue={ date?.utcString }
+				originalValue={ date.original }
+				parsedValue={ date.utcString }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&
@@ -150,8 +154,8 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 			/>
 			<Section
 				label="Content"
-				originalValue={ content?.original }
-				parsedValue={ content?.parsed }
+				originalValue={ content.original }
+				parsedValue={ content.parsed }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&

--- a/src/ui/flows/blog-post/SelectContent.tsx
+++ b/src/ui/flows/blog-post/SelectContent.tsx
@@ -126,7 +126,7 @@ export function SelectContent( props: { post: Post; onExit: () => void } ) {
 			<Section
 				label="Date"
 				originalValue={ date?.original }
-				parsedValue={ date?.parsed }
+				parsedValue={ date?.utcString }
 				disabled={ !! waitingForSelection }
 				waitingForSelection={
 					!! waitingForSelection &&


### PR DESCRIPTION
This PR makes it so that, when the user returns to the import screen of a post they have already selected things for, their previous selections are populated on screen. Additionally, they can clear individual fields with a new `Clear` button. 


## Screen capture
https://github.com/user-attachments/assets/02049536-af77-44e4-80f9-65c562994199