### PR TITLE
add updateSiteTitle method on ApiClient

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -2,6 +2,7 @@
 
 import { PlaygroundClient } from '@wp-playground/client';
 import { Post } from '@/api/Post';
+import { Settings } from '@/api/Settings';
 import { PostContent, PostDate, PostTitle } from '@/parser/post';
 
 export interface CreatePostBody {
@@ -58,6 +59,12 @@ export class ApiClient {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async getPostByGuid( guid: string ): Promise< Post | null > {
 		return null;
+	}
+
+	async updateSiteTitle( title: string ): Promise< Settings > {
+		return ( await this.post( `/settings`, {
+			title,
+		} ) ) as Settings;
 	}
 
 	private async get( route: string ): Promise< object > {

--- a/src/api/Settings.ts
+++ b/src/api/Settings.ts
@@ -1,0 +1,7 @@
+/* eslint-disable camelcase */
+
+import { WP_REST_API_Settings } from 'wp-types';
+
+export interface Settings extends WP_REST_API_Settings {}
+
+/* eslint-enable camelcase */


### PR DESCRIPTION
This PR adds a method to update the site title. Currently not called from anywhere.

WP exposes the settings endpoint:

```
curl http://localhost:8888/wp-json/wp/v2/settings | jq
```
```
{
  "title": "try-wordpress",
  "description": "",
  "url": "http://localhost:8888",
  "email": "wordpress@example.com",
  "timezone": "",
  "date_format": "F j, Y",
  "time_format": "g:i a",
  "start_of_week": 1,
  "language": "en_US",
  "use_smilies": true,
  "default_category": 1,
  "default_post_format": "0",
  "posts_per_page": 10,
  "show_on_front": "posts",
  "page_on_front": 0,
  "page_for_posts": 0,
  "default_ping_status": "open",
  "default_comment_status": "open",
  "site_logo": null,
  "site_icon": 0
}
```

Updating any of it, is just a POST call away:

```
curl -X POST "http://localhost:8888/wp-json/wp/v2/settings" \
-H "Content-Type: application/json" \
-d '{ "title": "Hello WordPress" }'
```
```
{"title":"Hello WordPress","description":"","url":"http:\/\/localhost:8888","email":"wordpress@example.com","timezone":"","date_format":"F j, Y","time_format":"g:i a","start_of_week":1,"language":"en_US","use_smilies":true,"default_category":1,"default_post_format":"0","posts_per_page":10,"show_on_front":"posts","page_on_front":0,"page_for_posts":0,"default_ping_status":"open","default_comment_status":"open","site_logo":null,"site_icon":0}
```