### PR TITLE
Make apiClient and playgroundClient available at the dev tools console

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -93,6 +93,14 @@ function App() {
 		playgroundClient,
 	};
 
+	// Debugging tools.
+	useEffect( () => {
+		if ( ! apiClient || !! ( window as any ).trywp ) {
+			return;
+		}
+		( window as any ).trywp = { apiClient, playgroundClient };
+	}, [ apiClient, playgroundClient ] );
+
 	const preview = ! session ? (
 		<PlaceholderPreview />
 	) : (


### PR DESCRIPTION
Thanks @ashfame for the suggestion

```
$ window.trywp.apiClient
$ window.trywp.playgroundClient
```