### PR TITLE
Add breadcrumbs

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,7 +8,6 @@ import {
 	Route,
 	RouterProvider,
 	useLocation,
-	useNavigate,
 	useRouteLoaderData,
 } from 'react-router-dom';
 import { StrictMode, useEffect, useState } from 'react';
@@ -22,6 +21,7 @@ import { SessionContext, SessionProvider } from '@/ui/session/SessionProvider';
 import { ApiClient } from '@/api/ApiClient';
 import { BlogPostFlow } from '@/ui/flows/blog-post/BlogPostFlow';
 import { PlaygroundClient } from '@wp-playground/client';
+import { Breadcrumbs } from '@/ui/breadcrumbs/Breadcrumbs';
 
 export const Screens = {
 	home: () => '/start/home',
@@ -119,27 +119,13 @@ function App() {
 	return (
 		<SessionProvider value={ sectionContext }>
 			<div className="app">
-				<Navbar className={ 'app-nav' } />
+				<Breadcrumbs className="breadcrumbs" />
 				<div className="app-main">
 					<Outlet />
 				</div>
 			</div>
 			<div className="preview">{ preview }</div>
 		</SessionProvider>
-	);
-}
-
-function Navbar( props: { className: string } ) {
-	const { className } = props;
-	const navigate = useNavigate();
-	return (
-		<nav className={ className }>
-			<ul>
-				<button onClick={ () => navigate( Screens.home() ) }>
-					Home
-				</button>
-			</ul>
-		</nav>
 	);
 }
 

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -30,13 +30,13 @@ ol {
 	border-right: 1px solid #000;
 }
 
-/* App Navbar */
-.app-nav {
+/* Breadcrumbs */
+.breadcrumbs {
 	height: 40px;
 	border-bottom: 1px solid #000;
 }
 
-.app-nav ul {
+.breadcrumbs ul {
 	padding: 5px;
 }
 

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -32,12 +32,19 @@ ol {
 
 /* Breadcrumbs */
 .breadcrumbs {
-	height: 40px;
+	padding: .5rem;
 	border-bottom: 1px solid #000;
 }
 
 .breadcrumbs ul {
-	padding: 5px;
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.breadcrumbs li:not(:last-child)::after {
+	display: inline-block;
+	margin: 0 .25rem;
+	content: "→";
 }
 
 /* App Main */

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -32,7 +32,7 @@ ol {
 
 /* Breadcrumbs */
 .breadcrumbs {
-	padding: .5rem;
+	padding: 0.5rem;
 	border-bottom: 1px solid #000;
 }
 
@@ -43,7 +43,7 @@ ol {
 
 .breadcrumbs li:not(:last-child)::after {
 	display: inline-block;
-	margin: 0 .25rem;
+	margin: 0 0.25rem;
 	content: "→";
 }
 

--- a/src/ui/breadcrumbs/Breadcrumbs.tsx
+++ b/src/ui/breadcrumbs/Breadcrumbs.tsx
@@ -1,15 +1,27 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Screens } from '@/ui/App';
+import { useSessionContext } from '@/ui/session/SessionProvider';
 
 export function Breadcrumbs( props: { className: string } ) {
 	const { className } = props;
-	const navigate = useNavigate();
+	const { session } = useSessionContext();
+	const location = useLocation();
+
+	const showSession = location.pathname.startsWith( '/session' );
+
 	return (
 		<nav className={ className }>
 			<ul>
-				<button onClick={ () => navigate( Screens.home() ) }>
-					Home
-				</button>
+				<li>
+					<Link to={ Screens.home() }>Home</Link>
+				</li>
+				{ ! showSession ? null : (
+					<li>
+						<Link to={ Screens.viewSession( session.id ) }>
+							{ session.title }
+						</Link>
+					</li>
+				) }
 			</ul>
 		</nav>
 	);

--- a/src/ui/breadcrumbs/Breadcrumbs.tsx
+++ b/src/ui/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom';
+import { Screens } from '@/ui/App';
+
+export function Breadcrumbs( props: { className: string } ) {
+	const { className } = props;
+	const navigate = useNavigate();
+	return (
+		<nav className={ className }>
+			<ul>
+				<button onClick={ () => navigate( Screens.home() ) }>
+					Home
+				</button>
+			</ul>
+		</nav>
+	);
+}


### PR DESCRIPTION
For the moment it only shows two levels (Home and "session"), but we can expand it in the future.

I needed this because I need to be able to go back without reloading playground, to test some features.

## Screen capture

<img width="467" alt="Screenshot 2024-09-24 at 17 17 10" src="https://github.com/user-attachments/assets/e4b05960-b8cd-4946-a100-4b2531c85bed">
