### PR TITLE
add createUser method on ApiClient

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -3,10 +3,20 @@
 import { PlaygroundClient } from '@wp-playground/client';
 import { Post } from '@/api/Post';
 import { Settings } from '@/api/Settings';
+import { User } from '@/api/User';
 import { PostContent, PostDate, PostTitle } from '@/parser/post';
 
 export interface CreatePostBody {
 	guid: string;
+}
+
+export interface CreateUserBody {
+	username: string;
+	email: string;
+	password: string;
+	roles?: [ string ]; // default roles: administrator, editor, author, subscriber (default)
+	firstname?: string;
+	lastname?: string;
 }
 
 export interface UpdatePostBody {
@@ -65,6 +75,24 @@ export class ApiClient {
 		return ( await this.post( `/settings`, {
 			title,
 		} ) ) as Settings;
+	}
+
+	async createUser( body: CreateUserBody ): Promise< User > {
+		const actualBody: any = {
+			username: body.username,
+			email: body.email,
+			password: body.password,
+		};
+		if ( body.roles ) {
+			actualBody.roles = body.roles;
+		}
+		if ( body.firstname ) {
+			actualBody.first_name = body.firstname;
+		}
+		if ( body.lastname ) {
+			actualBody.last_name = body.lastname;
+		}
+		return ( await this.post( `/users`, actualBody ) ) as User;
 	}
 
 	private async get( route: string ): Promise< object > {

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -14,7 +14,7 @@ export interface CreateUserBody {
 	username: string;
 	email: string;
 	password: string;
-	roles?: [ string ]; // default roles: administrator, editor, author, subscriber (default)
+	role?: string; // default roles: administrator, editor, author, subscriber (default)
 	firstname?: string;
 	lastname?: string;
 }
@@ -83,8 +83,8 @@ export class ApiClient {
 			email: body.email,
 			password: body.password,
 		};
-		if ( body.roles ) {
-			actualBody.roles = body.roles;
+		if ( body.role ) {
+			actualBody.roles = [ body.role ];
 		}
 		if ( body.firstname ) {
 			actualBody.first_name = body.firstname;

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -1,0 +1,7 @@
+/* eslint-disable camelcase */
+
+import { WP_REST_API_User } from 'wp-types';
+
+export interface User extends WP_REST_API_User {}
+
+/* eslint-enable camelcase */


### PR DESCRIPTION
This PR adds a method to create the user, which would be authors in our use case. Currently not called from anywhere.

`username`, `email` and `password` are 3 required fields, but only details I can imagine we would have to work with, would be `name` + possibly a `username` at times. `username` is also not modifiable. A DB query is possible of course but it escapes me why it's recommended to not change/edit `username`.

Regardless this isn't a problem, since we can create temp users with whatever data we have. Afterwards the administrator can create new users with the right details and then just delete the ones created by us. At delete, WordPress prompts with the option of re-assigning all content attributed to the user being deleted to another user. So, it works out.

```
window.trywp.apiClient.createUser({ "username": "aa", "email": "aa@a.com", "password": "aa", "roles":["author"], "firstname": "aaaa", "lastname": "kkkk" })
```