### PR TITLE
define WP_ENVIRONMENT_TYPE: 'local' in playground 

### DIFF
--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -68,6 +68,12 @@ async function initPlayground(
 function steps(): StepDefinition[] {
 	return [
 		{
+			step: 'defineWpConfigConsts',
+			consts: {
+				WP_ENVIRONMENT_TYPE: 'local',
+			},
+		},
+		{
 			step: 'login',
 			username: 'admin',
 			password: 'password',


### PR DESCRIPTION
Required to expose dev tooling's UI in WP admin.

@psrpinto @akirk

This works for now, but before releasing the extension, I think we would need a different value for `WP_ENVIRONMENT_TYPE` or it not be defined since default value is `production`, so that dev tooling UI is not exposed to the user. Perhaps a different set of steps for prod build, if we have the need?

I can create a new issue to track this, if we all agree that this UI should not be exposed to the end user.