### PR TITLE
Inspection UI: Pass 4 (Remove Add new link)

### DIFF
--- a/tests/plugin/test-promoter.php
+++ b/tests/plugin/test-promoter.php
@@ -34,6 +34,8 @@ class Promoter_Test extends TestCase {
 		$promoted_post_id = $this->promoter->get_promoted_post_id( $this->post_id_in_db );
 		wp_delete_post( $promoted_post_id, true );
 		wp_delete_post( $this->post_id_in_db, true );
+
+		delete_post_meta( 99, '_promoted_post' );
 	}
 
 	public function testGetPostTypeForPromotedPost() {


### PR DESCRIPTION
Mainly removes the "Add new" option for liberated_* CPT from a bunch of places, since it doesn't make sense for our use case.

<img width="799" alt="Screenshot 2024-10-04 at 19 25 30" src="https://github.com/user-attachments/assets/4c891985-cfdb-4bbb-a4d0-549c8029d44f">

