### PR TITLE
prevent double initialization of playground

### DIFF
--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import {
 	PlaygroundClient,
 	StartPlaygroundOptions,
@@ -16,15 +16,19 @@ export function Playground( props: {
 } ) {
 	const { slug, className, blogName, onReady } = props;
 
+	const initializationRef = useRef( false );
+
 	useEffect( () => {
 		const iframe = document.getElementById( playgroundIframeId );
 		if ( ! ( iframe instanceof HTMLIFrameElement ) ) {
 			throw Error( 'Playground container element must be an iframe' );
 		}
-		if ( iframe.src !== '' ) {
-			// Playground is already started.
+		if ( iframe.src !== '' || initializationRef.current ) {
+			// Playground is already started or initialization has been attempted.
 			return;
 		}
+
+		initializationRef.current = true;
 
 		initPlayground( iframe, slug, blogName )
 			.then( async ( client: PlaygroundClient ) => {
@@ -35,7 +39,7 @@ export function Playground( props: {
 			.catch( ( error ) => {
 				throw error;
 			} );
-	}, [ slug, onReady ] );
+	}, [ slug, onReady, blogName ] );
 
 	return (
 		<iframe


### PR DESCRIPTION
This PR prevents double initialization of playground client, to avoid unintended side-effects.

For persistence in playground, we need to pass a flag at second boot after first boot finishes up with setup. Double init messes up the setup. This PR unblocks the way.