### PR TITLE
mount OPFS for persistence in playground

### DIFF
--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -4,6 +4,7 @@ import {
 	StartPlaygroundOptions,
 	startPlaygroundWeb,
 	StepDefinition,
+	MountDescriptor,
 } from '@wp-playground/client';
 
 const playgroundIframeId = 'playground';
@@ -55,9 +56,26 @@ async function initPlayground(
 	slug: string,
 	blogName: string
 ): Promise< PlaygroundClient > {
+	const mountDescriptor: MountDescriptor = {
+		device: {
+			type: 'opfs',
+			path: '/try-wp-' + slug,
+		},
+		mountpoint: '/wordpress',
+	};
+
+	let isWordPressInstalled = false;
+	if ( localStorage.getItem( 'isWordPressInstalled' ) !== null ) {
+		isWordPressInstalled = true;
+	}
+
+	console.info( 'isWordPressInstalled', isWordPressInstalled );
+
 	const options: StartPlaygroundOptions = {
 		iframe,
-		remoteUrl: 'https://playground.wordpress.net/remote.html',
+		remoteUrl: `https://playground.wordpress.net/remote.html`,
+		mounts: [ mountDescriptor ],
+		shouldInstallWordPress: ! isWordPressInstalled,
 		blueprint: {
 			login: true,
 			steps: steps(),
@@ -68,7 +86,10 @@ async function initPlayground(
 	};
 
 	const client: PlaygroundClient = await startPlaygroundWeb( options );
-	await client.isReady;
+	await client.isReady();
+
+	localStorage.setItem( 'isWordPressInstalled', 'true' );
+
 	return client;
 }
 

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -59,7 +59,7 @@ async function initPlayground(
 	const mountDescriptor: MountDescriptor = {
 		device: {
 			type: 'opfs',
-			path: '/try-wp-' + slug,
+			path: '/try-wp-sites/' + slug,
 		},
 		mountpoint: '/wordpress',
 	};


### PR DESCRIPTION
This PR indicates playground to use an OPFS mount for persistence. It currently relies on localStorage to indicate playground whether it needs WP installed or not. In a future version, playground would handle this for us, so we will remove the localstorage bits.

Previous related PRs: #44 and #62
Fixes #43 

Props @akirk for localstorage hint to not wait for required change in Playground's api to land. 