### PR TITLE
Fix issue due to permalinks

### DIFF
--- a/src/api/BlogPosts.ts
+++ b/src/api/BlogPosts.ts
@@ -1,5 +1,10 @@
 /* eslint-disable camelcase */
 import { WP_REST_API_Post } from 'wp-types';
+type ApiPost = WP_REST_API_Post & {
+	preview_link: string;
+};
+/* eslint-enable camelcase */
+
 import { BlogPost } from '@/model/content/BlogPost';
 import { ApiClient } from '@/api/ApiClient';
 import {
@@ -11,12 +16,6 @@ import {
 	PostType,
 	TextField,
 } from '@/model/content/Post';
-
-type ApiPost = WP_REST_API_Post & {
-	preview_link: string;
-};
-
-/* eslint-enable camelcase */
 
 interface CreateBody {
 	guid: string;

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -129,6 +129,10 @@ function steps(): StepDefinition[] {
 		},
 		{
 			step: 'runPHP',
+			code: setPlainPermalinks(),
+		},
+		{
+			step: 'runPHP',
 			code: deleteDefaultContent(),
 		},
 		{
@@ -158,6 +162,13 @@ function steps(): StepDefinition[] {
 			data: authenticateRestRequest(),
 		},
 	];
+}
+
+function setPlainPermalinks(): string {
+	return `<?php
+require_once 'wordpress/wp-load.php';
+$option_result = update_option( 'permalink_structure', '');
+`;
 }
 
 function authenticateRestRequest(): string {

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -56,6 +56,8 @@ async function initPlayground(
 	slug: string,
 	blogName: string
 ): Promise< PlaygroundClient > {
+	const opfsEnabled = true;
+
 	const mountDescriptor: MountDescriptor = {
 		device: {
 			type: 'opfs',
@@ -70,8 +72,8 @@ async function initPlayground(
 	const options: StartPlaygroundOptions = {
 		iframe,
 		remoteUrl: `https://playground.wordpress.net/remote.html`,
-		mounts: [ mountDescriptor ],
-		shouldInstallWordPress: ! isWPInstalled,
+		mounts: opfsEnabled ? [ mountDescriptor ] : undefined,
+		shouldInstallWordPress: opfsEnabled ? ! isWPInstalled : undefined,
 		blueprint: {
 			login: true,
 			steps: steps(),


### PR DESCRIPTION
Currently, there's an issue that causes a 404 when trying to do the import blog post flow. 

Previously it used to work, but playground [changed the default permalink structure](https://github.com/WordPress/wordpress-playground/pull/1832/files), so that's probably why it's broken now.

This PR fixes the issue by setting the permalink structure to "plain". I guess ideally we should figure out why things break if the permalink structure is different than "plain", but right now I just want it to work :)

### Issue screenshot

<img width="949" alt="Screenshot 2024-10-21 at 14 22 30" src="https://github.com/user-attachments/assets/bbea2610-2322-439c-864b-675f1ac33c2a">
