### PR TITLE
Don't let promoted post's title be just its ID

### DIFF
--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -75,7 +75,7 @@ class Promoter {
 		// so that the post-slug is not just a number.
 		$title = $liberated_post->post_title;
 		if ( empty( $title ) ) {
-			$title = 'To be populated';
+			$title = '[Title]';
 		}
 
 		$args = array(

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -68,6 +68,16 @@ class Promoter {
 
 		$promoted_post_id = get_post_meta( $liberated_post->ID, $this->meta_key_for_promoted_post, true );
 
+		// An immediately cloned post with no data and just the guid in meta,
+		// would have its slug as just the post id. I believe being just a number
+		// it gets caught up in some bad regex with playground.
+		// To overcome that, we temporarily set the title here to be string,
+		// so that the post-slug is not just a number.
+		$title = $liberated_post->post_title;
+		if ( empty( $title ) ) {
+			$title = 'To be populated';
+		}
+
 		$args = array(
 			'post_author'       => $liberated_post->post_author,
 			'post_date'         => $liberated_post->post_date,
@@ -75,7 +85,7 @@ class Promoter {
 			'post_modified'     => $liberated_post->post_modified,
 			'post_modified_gmt' => $liberated_post->post_modified_gmt,
 			'post_content'      => $liberated_post->post_content,
-			'post_title'        => $liberated_post->post_title,
+			'post_title'        => $title,
 			'post_excerpt'      => $liberated_post->post_excerpt,
 			'post_status'       => 'publish',
 			'comment_status'    => $liberated_post->comment_status,

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -98,9 +98,7 @@ class Promoter {
 			$args['ID'] = $promoted_post_id;
 		}
 
-		add_filter( 'wp_insert_post_empty_content', '__return_false' );
 		$inserted_post_id = wp_insert_post( $args, true );
-		remove_filter( 'wp_insert_post_empty_content', '__return_false' );
 
 		// @TODO: handle attachments, terms etc in future
 		// Note: Do not need anything from postmeta.


### PR DESCRIPTION
WP chooses the post ID to be its post slug when the post is promoted for the first time, since it only has guid in postmeta and literally nothing else.

This causes a 404 to appear until you choose more data and post title is updated & hence the post url. Suspect a bad regex in playground to be the cause.

This fixes it for us.