### PR TITLE
Simplify backend (Define custom endpoints for blogpost subject type + foundation bits)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 		"dev:db": "wp-env run cli wp db export - > backup.sql",
 		"dev:db:backup": "wp-env run cli wp db export - > backup-$(date +%Y%m%d-%H%M%S).sql",
 		"dev:test": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit",
-		"dev:test:api": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --filter 'Controller_Test'"
+		"dev:test:api": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --filter 'Controller_Test'",
+		"dev:test:failing": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --group failing"
 	},
 	"config": {
 		"vendor-dir": "src/plugin/vendor",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 		],
 		"dev:db": "wp-env run cli wp db export - > backup.sql",
 		"dev:db:backup": "wp-env run cli wp db export - > backup-$(date +%Y%m%d-%H%M%S).sql",
-		"dev:test": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit"
+		"dev:test": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit",
+		"dev:test:api": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --filter 'Controller_Test'"
 	},
 	"config": {
 		"vendor-dir": "src/plugin/vendor",

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -92,6 +92,19 @@ class Blogpost_Controller extends Liberate_Controller {
 			10,
 			2
 		);
+
+		// Bust guid -> postId cache when a post is deleted
+		add_filter(
+			'delete_post_' . $this->storage_post_type,
+			function ( $post_id, $post ) {
+				$cache_group = 'try_wp';
+				$cache_key   = 'try_wp_cache_guid_' . md5( $post->guid );
+
+				wp_cache_delete( $cache_key, $cache_group );
+			},
+			10,
+			2
+		);
 	}
 
 	public function get_item_schema(): array {
@@ -236,7 +249,24 @@ class Blogpost_Controller extends Liberate_Controller {
 			);
 		}
 
+		// Use wp_cache_* for guid -> postId
+		$cache_group = 'try_wp';
+		$cache_key   = 'try_wp_cache_guid_' . md5( $guid );
+		$post_id     = wp_cache_get( $cache_key, $cache_group );
+
+		if ( false !== $post_id ) {
+			// Cache hit - get post using WordPress API
+			$post = get_post( $post_id, ARRAY_A );
+			if ( $post ) {
+				return $this->prepare_item_for_response( $post, $request );
+			}
+			// If post not found despite cache hit, delete the cache
+			wp_cache_delete( $cache_key, $cache_group );
+		}
+
+		// Cache miss - query database
 		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$post = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT * FROM $wpdb->posts WHERE guid = %s",
@@ -246,6 +276,8 @@ class Blogpost_Controller extends Liberate_Controller {
 		);
 
 		if ( $post ) {
+			// Cache the post ID for future lookups
+			wp_cache_set( $cache_key, $post['ID'], $cache_group, YEAR_IN_SECONDS );
 			return $this->prepare_item_for_response( $post, $request );
 		}
 

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -29,6 +29,12 @@ class Blogpost_Controller extends Liberate_Controller {
 					'permission_callback' => '__return_true',
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'search_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::READABLE ),
+				),
 			)
 		);
 		register_rest_route(
@@ -217,5 +223,36 @@ class Blogpost_Controller extends Liberate_Controller {
 		}
 
 		return new WP_Error( 'rest_could_not_delete', __( 'Could not delete', 'try_wordpress' ), array( 'status' => 500 ) );
+	}
+
+	public function search_item( $request ): WP_Error|WP_REST_Response {
+		$guid = $request['sourceurl'] ?? '';
+
+		if ( empty( $guid ) ) {
+			return new WP_Error(
+				'rest_search_invalid_sourceurl',
+				__( 'Invalid source URL.', 'try_wordpress' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		global $wpdb;
+		$post = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM $wpdb->posts WHERE guid = %s",
+				$guid
+			),
+			ARRAY_A
+		);
+
+		if ( $post ) {
+			return $this->prepare_item_for_response( $post, $request );
+		}
+
+		return new WP_Error(
+			'rest_not_found',
+			__( 'Not found', 'try_wordpress' ),
+			array( 'status' => 404 )
+		);
 	}
 }

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use WP_Error;
+use WP_REST_Response;
+use WP_REST_Server;
+
+class Blogpost_Controller extends Liberate_Controller {
+
+	public function __construct( $storage_post_type ) {
+		parent::__construct( $storage_post_type );
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		$this->attach_filters();
+	}
+
+	// @TODO: This function can become register_liberation_routes and be moved to Liberate_Controller
+	// register_liberation_routes( $namespace, $subject_type )
+	public function register_routes(): void {
+		$version      = '1';
+		$namespace    = 'try-wp/v' . $version;
+		$subject_type = 'blogpost';
+		register_rest_route(
+			$namespace,
+			'/' . $subject_type,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+			)
+		);
+		register_rest_route(
+			$namespace,
+			'/' . $subject_type . '/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'context' => array(
+							'default' => 'view',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'force' => array(
+							'default' => false,
+						),
+					),
+				),
+			)
+		);
+		register_rest_route(
+			$namespace,
+			'/' . $subject_type . '/schema',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_public_item_schema' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	public function attach_filters(): void {
+		add_filter(
+			'wp_insert_post_empty_content',
+			function ( $maybe_empty, $postarr ) {
+				if ( $postarr['post_type'] === $this->storage_post_type ) {
+					return false;
+				}
+				return $maybe_empty;
+			},
+			10,
+			2
+		);
+	}
+
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->schema;
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'blogpost',
+			'type'       => 'object',
+			'properties' => array(
+				'id'            => array(
+					'description' => __( 'Unique identifier for liberated blogpost', 'try_wordpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'title'         => array(
+					'description' => __( 'Title of the liberated blogpost', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'date'          => array(
+					'description' => __( 'Published datetime of the liberated blogpost', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'content'       => array(
+					'description' => __( 'Content of the liberated blogpost', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field', // we don't want to modify any HTML
+					),
+				),
+				'sourceUrl'     => array(
+					'description' => __( 'Source URL from where the blogpost was liberated', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => true,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'transformedId' => array(
+					'description' => __( 'Post ID of transformed result of this liberated blogpost', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			),
+		);
+
+		$this->schema = $schema;
+		return $this->schema;
+	}
+
+	public function get_item( $request ): WP_REST_Response|WP_Error {
+		$post_id = $request['id'];
+		$item    = get_post( $post_id, ARRAY_A );
+		if ( is_null( $item ) ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'try_wordpress' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $this->prepare_item_for_response( $item, $request );
+	}
+
+	public function create_item( $request ): WP_REST_Response|WP_Error {
+		$item = $this->prepare_item_for_database( $request );
+
+		$result = wp_insert_post( $item, true );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$item['ID'] = $result;
+
+		return $this->prepare_item_for_response( $item, $request );
+	}
+
+	public function update_item( $request ): WP_REST_Response|WP_Error {
+		$item = $this->prepare_item_for_database( $request );
+
+		$result = wp_insert_post( $item, true );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $this->prepare_item_for_response( $item, $request );
+	}
+
+	public function delete_item( $request ): WP_Error|WP_REST_Response {
+		$post_id = $request['id'];
+
+		$item = get_post( $post_id );
+		if ( is_null( $item ) ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'try_wordpress' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( wp_trash_post( $request['id'] ) ) {
+			return new WP_REST_Response( true, 200 );
+		}
+
+		return new WP_Error( 'rest_could_not_delete', __( 'Could not delete', 'try_wordpress' ), array( 'status' => 500 ) );
+	}
+}

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -15,8 +15,6 @@ class Blogpost_Controller extends Liberate_Controller {
 		$this->attach_filters();
 	}
 
-	// @TODO: This function can become register_liberation_routes and be moved to Liberate_Controller
-	// register_liberation_routes( $namespace, $subject_type )
 	public function register_routes(): void {
 		$version      = '1';
 		$namespace    = 'try-wp/v' . $version;
@@ -186,7 +184,13 @@ class Blogpost_Controller extends Liberate_Controller {
 	}
 
 	public function update_item( $request ): WP_REST_Response|WP_Error {
-		$item = $this->prepare_item_for_database( $request );
+		$valid_request_for_update = $this->valid_request_for_update( $request );
+		if ( is_wp_error( $valid_request_for_update ) ) {
+			return $valid_request_for_update;
+		}
+
+		$item       = $this->prepare_item_for_database( $request );
+		$item['ID'] = $request['id'];
 
 		$result = wp_insert_post( $item, true );
 		if ( is_wp_error( $result ) ) {

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -4,13 +4,16 @@ namespace DotOrg\TryWordPress;
 
 class Engine {
 
-	private string $storage_post_type = 'liberated_data';
+	private string $storage_post_type      = 'liberated_data';
+	private array $liberated_content_types = array( 'blogpost', 'nav' );
 
 	public function __construct() {
 		require 'class-post-type-ui.php';
 		require 'class-promoter.php';
 		require 'class-meta-fields-manager.php';
 		require 'class-rest-api-extender.php';
+		require 'class-liberate-controller.php';
+		require 'class-blogpost-controller.php';
 		require 'class-storage.php';
 
 		( function () {
@@ -19,6 +22,8 @@ class Engine {
 			new Post_Type_UI( $this->storage_post_type, $promoter );
 			new Meta_Fields_Manager( $this->storage_post_type );
 
+			// REST API
+			new Blogpost_Controller( $this->storage_post_type );
 			new Rest_API_Extender( $this->storage_post_type, $promoter );
 
 			new Storage( $this->storage_post_type );

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -4,6 +4,8 @@ namespace DotOrg\TryWordPress;
 
 class Engine {
 
+	private string $storage_post_type = 'liberated_data';
+
 	public function __construct() {
 		require 'class-post-type-ui.php';
 		require 'class-promoter.php';
@@ -12,16 +14,14 @@ class Engine {
 		require 'class-storage.php';
 
 		( function () {
-			$custom_post_type = Storage::POST_TYPE;
+			$promoter = new Promoter( $this->storage_post_type );
 
-			$promoter = new Promoter( $custom_post_type );
+			new Post_Type_UI( $this->storage_post_type, $promoter );
+			new Meta_Fields_Manager( $this->storage_post_type );
 
-			new Post_Type_UI( $custom_post_type, $promoter );
-			new Meta_Fields_Manager( $custom_post_type );
+			new Rest_API_Extender( $this->storage_post_type, $promoter );
 
-			new Rest_API_Extender( $custom_post_type, $promoter );
-
-			new Storage();
+			new Storage( $this->storage_post_type );
 		} )();
 	}
 }

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+class Engine {
+
+	public function __construct() {
+		require 'class-post-type-ui.php';
+		require 'class-promoter.php';
+		require 'class-meta-fields-manager.php';
+		require 'class-rest-api-extender.php';
+		require 'class-storage.php';
+
+		( function () {
+			$custom_post_type = Storage::POST_TYPE;
+
+			$promoter = new Promoter( $custom_post_type );
+
+			new Post_Type_UI( $custom_post_type, $promoter );
+			new Meta_Fields_Manager( $custom_post_type );
+
+			new Rest_API_Extender( $custom_post_type, $promoter );
+
+			new Storage();
+		} )();
+	}
+}

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -28,6 +28,13 @@ class Liberate_Controller extends WP_REST_Controller {
 			'sourceUrl' => $item['guid'] ?? '',
 		);
 
+		if ( ! empty( $item['ID'] ) ) {
+			$transformed_post = get_post_meta( $item['ID'], '_dl_transformed', true );
+			if ( $transformed_post ) {
+				$response['previewUrl'] = get_post_permalink( $transformed_post );
+			}
+		}
+
 		return new WP_REST_Response( $response );
 	}
 

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Response;
+
+class Liberate_Controller extends WP_REST_Controller {
+
+	protected string $storage_post_type;
+
+	public function __construct( $storage_post_type ) {
+		$this->storage_post_type = $storage_post_type;
+	}
+
+	public function get_storage_post_type(): string {
+		return $this->storage_post_type;
+	}
+
+	public function prepare_item_for_response( $item, $request ): WP_REST_Response|WP_Error {
+		$response = array(
+			'id'        => $item['ID'] ?? '',
+			'authorId'  => $item['post_author'] ?? '',
+			'title'     => $item['post_title'] ?? '',
+			'content'   => $item['post_content'] ?? '',
+			'date'      => $item['post_date'] ?? '',
+			'sourceUrl' => $item['guid'] ?? '',
+		);
+
+		return new WP_REST_Response( $response );
+	}
+
+	public function prepare_item_for_database( $request ): WP_Error|array {
+		$prepared_post = array();
+
+		// Check if we're doing an update, we have a valid post id to work with
+		if ( isset( $request['id'] ) ) {
+			$existing_post = get_post( $request['id'] );
+			if ( is_null( $existing_post ) ) {
+				return new WP_Error(
+					'rest_invalid_id',
+					__( 'Invalid ID.', 'try_wordpress' ),
+					array( 'status' => 400 )
+				);
+			}
+			$prepared_post['ID'] = $request['id'];
+		}
+
+		$request_data = json_decode( $request->get_body(), true );
+
+		// Prepare $postarr that can be passed to wp_insert_post()
+		$prepared_post['post_type']    = $this->storage_post_type;
+		$prepared_post['post_title']   = $request_data['title'] ?? '';
+		$prepared_post['post_content'] = $request_data['content'] ?? '';
+		$prepared_post['guid']         = $request_data['sourceUrl'] ?? '';
+		$prepared_post['post_date']    = $request_data['date'] ?? '';
+		$prepared_post['post_author']  = $request_data['authorId'] ?? '';
+
+		return $prepared_post;
+	}
+}

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -18,6 +18,31 @@ class Liberate_Controller extends WP_REST_Controller {
 		return $this->storage_post_type;
 	}
 
+	public function valid_request_for_update( $request ): bool|WP_Error {
+		// Rule1: if post id is specified, it must be a valid id
+		$post_id = $request['id'];
+		$item    = get_post( $post_id );
+		if ( is_null( $item ) ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'try_wordpress' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Rule2: if sourceUrl is supplied, it must be the same as already saved
+		$request_data = json_decode( $request->get_body(), true );
+		if ( isset( $request_data['sourceUrl'] ) && $request_data['sourceUrl'] !== $item->guid ) {
+			return new WP_Error(
+				'rest_source_url_immutable',
+				__( 'Source URL is immutable', 'try_wordpress' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
 	public function prepare_item_for_response( $item, $request ): WP_REST_Response|WP_Error {
 		$response = array(
 			'id'        => $item['ID'] ?? '',
@@ -40,21 +65,7 @@ class Liberate_Controller extends WP_REST_Controller {
 
 	public function prepare_item_for_database( $request ): WP_Error|array {
 		$prepared_post = array();
-
-		// Check if we're doing an update, we have a valid post id to work with
-		if ( isset( $request['id'] ) ) {
-			$existing_post = get_post( $request['id'] );
-			if ( is_null( $existing_post ) ) {
-				return new WP_Error(
-					'rest_invalid_id',
-					__( 'Invalid ID.', 'try_wordpress' ),
-					array( 'status' => 400 )
-				);
-			}
-			$prepared_post['ID'] = $request['id'];
-		}
-
-		$request_data = json_decode( $request->get_body(), true );
+		$request_data  = json_decode( $request->get_body(), true );
 
 		// Prepare $postarr that can be passed to wp_insert_post()
 		$prepared_post['post_type']    = $this->storage_post_type;

--- a/src/plugin/class-promoter.php
+++ b/src/plugin/class-promoter.php
@@ -5,7 +5,7 @@ namespace DotOrg\TryWordPress;
 use WP_Post;
 
 class Promoter {
-	private string $meta_key_for_promoted_post = '_promoted_post';
+	private string $meta_key_for_promoted_post = '_dl_transformed';
 
 	public function __construct( $post_type ) {
 		// constantly promote for now

--- a/src/plugin/class-rest-api-extender.php
+++ b/src/plugin/class-rest-api-extender.php
@@ -28,24 +28,7 @@ class Rest_API_Extender {
 		add_filter( 'rest_prepare_' . $this->post_type, array( $this, 'inject_preview_link' ), 10, 3 );
 	}
 
-	public function register_route(): void {
-		register_rest_route(
-			'wp/v2',
-			'/' . $this->post_type . '/(?P<id>\d+)/promote',
-			array(
-				'methods'             => 'POST',
-				'callback'            => array( $this, 'promote_post' ),
-				'permission_callback' => '__return_true',
-				'args'                => array(
-					'id' => array(
-						'validate_callback' => function ( $param, $request, $key ) {
-							return is_numeric( $param );
-						},
-					),
-				),
-			)
-		);
-	}
+	public function register_route(): void {}
 
 	public function promote_post( WP_REST_Request $request ): WP_Error|WP_REST_Response {
 		$post_id = $request['id'];

--- a/src/plugin/class-storage.php
+++ b/src/plugin/class-storage.php
@@ -3,21 +3,24 @@
 namespace DotOrg\TryWordPress;
 
 class Storage {
-	const string POST_TYPE      = 'liberated_data';
-	const string POST_TYPE_NAME = 'Liberated Data';
+	private string $post_type;
+	private string $post_type_name;
 
 	private array $custom_post_types_supports = array( 'title', 'editor', 'custom-fields' );
 
-	public function __construct() {
+	public function __construct( string $post_type ) {
+		$this->post_type      = $post_type;
+		$this->post_type_name = ucwords( str_replace( '_', ' ', $post_type ) );
+
 		add_action( 'init', array( $this, 'register_post_types' ) );
 	}
 
 	private function get_singular_name(): string {
-		return self::POST_TYPE_NAME;
+		return $this->post_type_name;
 	}
 
 	private function get_plural_name(): string {
-		return self::POST_TYPE_NAME;
+		return $this->post_type_name;
 	}
 
 	public function register_post_types(): void {
@@ -34,13 +37,13 @@ class Storage {
 			'menu_icon'           => 'dashicons-database',
 			'supports'            => $this->custom_post_types_supports,
 			'labels'              => $this->get_post_type_registration_labels( $name, $name_plural ),
-			'rest_base'           => self::POST_TYPE,
+			'rest_base'           => $this->post_type,
 		);
 
-		register_post_type( self::POST_TYPE, $args );
+		register_post_type( $this->post_type, $args );
 	}
 
-	public function get_post_type_registration_labels( $name, $name_plural ): array {
+	public function get_post_type_registration_labels( string $name, string $name_plural ): array {
 		return array(
 			'name'                  => $name_plural,
 			'singular_name'         => $name,

--- a/src/plugin/plugin.php
+++ b/src/plugin/plugin.php
@@ -12,21 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require 'class-post-type-ui.php';
-require 'class-promoter.php';
-require 'class-meta-fields-manager.php';
-require 'class-rest-api-extender.php';
-require 'class-storage.php';
+require 'class-engine.php';
 
-( function () {
-	$custom_post_type = Storage::POST_TYPE;
-
-	$promoter = new Promoter( $custom_post_type );
-
-	new Post_Type_UI( $custom_post_type, $promoter );
-	new Meta_Fields_Manager( $custom_post_type );
-
-	new Rest_API_Extender( $custom_post_type, $promoter );
-
-	new Storage();
-} )();
+new Engine();

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -102,17 +102,15 @@ class Blogpost_Controller_Test extends TestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$response_data = $response->get_data();
-		$this->assertEquals(
-			array(
-				'id'        => 6,
-				'title'     => $post_title,
-				'content'   => $post_content,
-				'date'      => $date,
-				'sourceUrl' => $source_url,
-				'authorId'  => $author_id,
-			),
-			$response_data
-		);
+
+		$this->assertEquals( 6, $response_data['id'] );
+		$this->assertEquals( $author_id, $response_data['authorId'] );
+		$this->assertEquals( $post_title, $response_data['title'] );
+		$this->assertEquals( $post_content, $response_data['content'] );
+		$this->assertEquals( $date, $response_data['date'] );
+		$this->assertEquals( $source_url, $response_data['sourceUrl'] );
+
+		$this->assertNotEmpty( $response_data['previewUrl'] );
 
 		// read from db
 		$post = get_post( $response_data['id'] );

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -300,4 +300,44 @@ class Blogpost_Controller_Test extends TestCase {
 
 		$this->assertEquals( 404, $response->get_status() );
 	}
+
+	public function testGuidCache(): void {
+		$sourceUrl   = 'https://example.org/guidcachetesting';
+		$cache_group = 'try_wp';
+		$cache_key   = 'try_wp_cache_guid_' . md5( $sourceUrl );
+
+		// First create a post
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => $sourceUrl,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+		$post_id  = $response->get_data()['id'];
+
+		// do a look up, so that it gets cached
+		$request = new WP_REST_Request( 'GET', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_query_params(
+			array(
+				'sourceurl' => $sourceUrl,
+			)
+		);
+
+		rest_do_request( $request );
+
+		// Verify cache was set
+		$this->assertEquals( $post_id, wp_cache_get( $cache_key, $cache_group ) );
+
+		// Delete the post
+		wp_delete_post( $post_id );
+
+		// Verify the cache was cleared
+		$this->assertFalse( wp_cache_get( $cache_key, $cache_group ) );
+	}
 }

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -231,4 +231,73 @@ class Blogpost_Controller_Test extends TestCase {
 
 		$this->assertEquals( 404, $response->get_status() );
 	}
+
+	public function testFindBySourceUrlNoArgs() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'GET', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function testFindBySourceUrlNoUrl() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'GET', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_query_params(
+			array(
+				'sourceurl' => '',
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function testFindBySourceUrlValidUrl() {
+		// First create a post to lookup
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => 'https://example.org/lookmeup',
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+		$post_id  = $response->get_data()['id'];
+
+		$request = new WP_REST_Request( 'GET', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_query_params(
+			array(
+				'sourceurl' => 'https://example.org/lookmeup',
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $post_id, $response->get_data()['id'] );
+	}
+
+	public function testFindBySourceUrlInvalidUrl() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'GET', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_query_params(
+			array(
+				'sourceurl' => 'https://example.org/nonexistent',
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
 }

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -1,0 +1,125 @@
+<?php
+
+use DotOrg\TryWordPress\Blogpost_Controller;
+use PHPUnit\Framework\TestCase;
+
+class Blogpost_Controller_Test extends TestCase {
+	private string $namespace    = 'try-wp/v1';
+	private string $subject_type = 'blogpost';
+	private Blogpost_Controller $blogpost_controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$storage_post_type = 'lib_1';
+
+		$this->blogpost_controller = new Blogpost_Controller( $storage_post_type );
+	}
+
+	public function testRegisterRoutes(): void {
+		do_action( 'rest_api_init' ); // so that register_route() executes.
+
+		$routes = rest_get_server()->get_routes( $this->namespace );
+		$this->assertArrayHasKey( '/' . $this->namespace . '/blogpost', $routes );
+		$this->assertArrayHasKey( '/' . $this->namespace . '/blogpost/(?P<id>\d+)', $routes );
+		$this->assertArrayHasKey( '/' . $this->namespace . '/blogpost/schema', $routes );
+	}
+
+	public function test_schema_endpoint() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/schema';
+
+		$request  = new WP_REST_Request( 'GET', $api_endpoint );
+		$response = rest_do_request( $request );
+
+		$schema = $this->blogpost_controller->get_item_schema();
+		$this->assertEquals(
+			$this->remove_arg_options_from_schema( $schema ),
+			$response->get_data()
+		);
+	}
+
+	private function remove_arg_options_from_schema( &$schema ) {
+		foreach ( $schema['properties'] as &$property ) {
+			unset( $property['arg_options'] );
+		}
+		return $schema;
+	}
+
+	public function test_create_item_no_body() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+
+		$request = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_create_item_minimal_body() {
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$source_url   = 'https://example.org/1';
+
+		$request = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => $source_url,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// read from db
+		$post = get_post( $response->get_data()['id'] );
+		$this->assertEquals( $source_url, $post->guid );
+	}
+
+	public function test_create_item_full_body() {
+		$date         = '2000-10-25 18:39:03';
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$source_url   = 'https://example.org/2';
+		$post_title   = 'This is an awesome post title';
+		$post_content = 'This is an awesome post body';
+		$author_id    = 23;
+
+		$request = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => $source_url,
+					'title'     => $post_title,
+					'content'   => $post_content,
+					'date'      => $date,
+					'authorId'  => $author_id,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'        => 6,
+				'title'     => $post_title,
+				'content'   => $post_content,
+				'date'      => $date,
+				'sourceUrl' => $source_url,
+				'authorId'  => $author_id,
+			),
+			$response_data
+		);
+
+		// read from db
+		$post = get_post( $response_data['id'] );
+		$this->assertEquals( $source_url, $post->guid );
+		$this->assertEquals( $post_title, $post->post_title );
+		$this->assertEquals( $post_content, $post->post_content );
+		$this->assertEquals( $author_id, $post->post_author );
+		$this->assertEquals( $date, $post->post_date );
+	}
+}

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -25,7 +25,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertArrayHasKey( '/' . $this->namespace . '/blogpost/schema', $routes );
 	}
 
-	public function test_schema_endpoint() {
+	public function testSchemaEndpoint() {
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/schema';
 
 		$request  = new WP_REST_Request( 'GET', $api_endpoint );
@@ -45,7 +45,7 @@ class Blogpost_Controller_Test extends TestCase {
 		return $schema;
 	}
 
-	public function test_create_item_no_body() {
+	public function testCreateItemEmptyBody() {
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
 
 		$request = new WP_REST_Request( 'POST', $api_endpoint );
@@ -55,7 +55,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
-	public function test_create_item_minimal_body() {
+	public function testCreateItemMinimalBody() {
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
 		$source_url   = 'https://example.org/1';
 
@@ -77,7 +77,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $source_url, $post->guid );
 	}
 
-	public function test_create_item_full_body() {
+	public function testCreateItemFullBody() {
 		$date         = '2000-10-25 18:39:03';
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
 		$source_url   = 'https://example.org/2';
@@ -121,7 +121,31 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $date, $post->post_date );
 	}
 
-	public function test_update_item() {
+	public function testCreateItemMissingSourceUrl() {
+		$date         = '2000-10-25 18:39:03';
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$post_title   = 'This is an awesome post title';
+		$post_content = 'This is an awesome post body';
+		$author_id    = 23;
+
+		$request = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'    => $post_title,
+					'content'  => $post_content,
+					'date'     => $date,
+					'authorId' => $author_id,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function testUpdateItem() {
 		// First create a post to update
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
 		$source_url   = 'https://example.org/original';
@@ -172,7 +196,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $source_url, $post->guid );
 	}
 
-	public function test_delete_item() {
+	public function testDeleteItem() {
 		// First create a post to delete
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
 		$request      = new WP_REST_Request( 'POST', $api_endpoint );
@@ -200,7 +224,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( 'trash', $post->post_status );
 	}
 
-	public function test_delete_nonexistent_item() {
+	public function testDeleteNonexistentItem() {
 		$delete_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/99999';
 		$request         = new WP_REST_Request( 'DELETE', $delete_endpoint );
 		$response        = rest_do_request( $request );

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -120,4 +120,91 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $author_id, $post->post_author );
 		$this->assertEquals( $date, $post->post_date );
 	}
+
+	public function test_update_item() {
+		// First create a post to update
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$source_url   = 'https://example.org/original';
+		$request      = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => $source_url,
+					'title'     => 'Original Title',
+					'content'   => 'Original Content',
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+		$post_id  = $response->get_data()['id'];
+
+		// Now update the post
+		$update_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/' . $post_id;
+		$new_title       = 'Updated Title';
+		$new_content     = 'Updated Content';
+
+		$request = new WP_REST_Request( 'PUT', $update_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'     => $new_title,
+					'content'   => $new_content,
+					'sourceUrl' => $source_url,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_data = $response->get_data();
+
+		// Verify response data
+		$this->assertEquals( $post_id, $response_data['id'] );
+		$this->assertEquals( $new_title, $response_data['title'] );
+		$this->assertEquals( $new_content, $response_data['content'] );
+		$this->assertEquals( $source_url, $response_data['sourceUrl'] );
+
+		// Verify database update
+		$post = get_post( $post_id );
+		$this->assertEquals( $new_title, $post->post_title );
+		$this->assertEquals( $new_content, $post->post_content );
+		$this->assertEquals( $source_url, $post->guid );
+	}
+
+	public function test_delete_item() {
+		// First create a post to delete
+		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
+		$request      = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => 'https://example.org/to-delete',
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+		$post_id  = $response->get_data()['id'];
+
+		// Now delete the post
+		$delete_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/' . $post_id;
+		$request         = new WP_REST_Request( 'DELETE', $delete_endpoint );
+		$response        = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data() );
+
+		// Verify post is in trash
+		$post = get_post( $post_id );
+		$this->assertEquals( 'trash', $post->post_status );
+	}
+
+	public function test_delete_nonexistent_item() {
+		$delete_endpoint = '/' . $this->namespace . '/' . $this->subject_type . '/99999';
+		$request         = new WP_REST_Request( 'DELETE', $delete_endpoint );
+		$response        = rest_do_request( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
 }

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -302,9 +302,9 @@ class Blogpost_Controller_Test extends TestCase {
 	}
 
 	public function testGuidCache(): void {
-		$sourceUrl   = 'https://example.org/guidcachetesting';
+		$source_url  = 'https://example.org/guidcachetesting';
 		$cache_group = 'try_wp';
-		$cache_key   = 'try_wp_cache_guid_' . md5( $sourceUrl );
+		$cache_key   = 'try_wp_cache_guid_' . md5( $source_url );
 
 		// First create a post
 		$api_endpoint = '/' . $this->namespace . '/' . $this->subject_type;
@@ -313,7 +313,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'sourceUrl' => $sourceUrl,
+					'sourceUrl' => $source_url,
 				)
 			)
 		);
@@ -325,7 +325,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_query_params(
 			array(
-				'sourceurl' => $sourceUrl,
+				'sourceurl' => $source_url,
 			)
 		);
 

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -15,12 +15,67 @@ class Liberate_Controller_Test extends TestCase {
 		$this->inserted_post_id    = wp_insert_post(
 			array(
 				'post_title' => 'hello unit tests',
+				'post_type'  => $this->storage_post_type,
 			)
 		);
 	}
 
 	public function testGetStoragePostType() {
 		$this->assertEquals( $this->storage_post_type, $this->liberate_controller->get_storage_post_type() );
+	}
+
+	public function testValidRequestForUpdateRule1() {
+		// invalid id, rule 1 violation
+		$api_endpoint = '/try-wp/v1/blogpost/9999';
+		$request      = new WP_REST_Request( 'POST', $api_endpoint );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title' => 'Some title',
+				)
+			)
+		);
+		rest_do_request( $request );
+
+		$result = $this->liberate_controller->valid_request_for_update( $request );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_post_invalid_id', $result->get_error_code() );
+	}
+
+	public function testValidRequestForUpdateRule2() {
+		// attempting to update sourceUrl/guid, rule 2 violation
+		$api_endpoint = '/try-wp/v1/blogpost/' . $this->inserted_post_id;
+		$request      = new WP_REST_Request( 'PUT', $api_endpoint );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'     => 'Updated title',
+					'sourceUrl' => 'https://example.org/different',
+				)
+			)
+		);
+		rest_do_request( $request );
+
+		$result = $this->liberate_controller->valid_request_for_update( $request );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_source_url_immutable', $result->get_error_code() );
+	}
+
+	public function testValidRequestForUpdateSuccess() {
+		// valid id and same sourceUrl specified
+		$request = new WP_REST_Request( 'POST', '/try-wp/v1/blogpost/' . $this->inserted_post_id );
+		$request->set_query_params( array( 'id' => $this->inserted_post_id ) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'     => 'Some title',
+					'sourceUrl' => get_permalink( $this->inserted_post_id ),
+				)
+			)
+		);
+		rest_do_request( $request );
+
+		$this->assertTrue( $this->liberate_controller->valid_request_for_update( $request ) );
 	}
 
 	public function testPrepareItemForResponse() {
@@ -76,28 +131,18 @@ class Liberate_Controller_Test extends TestCase {
 				array(
 					'title'     => 'This is the test title',
 					'content'   => 'This is the test content',
-					'sourceUrl' => 'https://example.org/70',
+					'sourceUrl' => get_permalink( $this->inserted_post_id ),
 					'date'      => $this->date,
 				)
 			)
 		);
+		rest_do_request( $request );
 
-		// test create attempt
 		$result = $this->liberate_controller->prepare_item_for_database( $request );
 		$this->assertEquals( $this->liberate_controller->get_storage_post_type(), $result['post_type'] );
 		$this->assertEquals( 'This is the test title', $result['post_title'] );
 		$this->assertEquals( 'This is the test content', $result['post_content'] );
-		$this->assertEquals( 'https://example.org/70', $result['guid'] );
+		$this->assertEquals( get_permalink( $this->inserted_post_id ), $result['guid'] );
 		$this->assertEquals( $this->date, $result['post_date'] );
-
-		// test update attempt - valid id
-		$request->set_query_params( array( 'id' => $this->inserted_post_id ) );
-		$result = $this->liberate_controller->prepare_item_for_database( $request );
-		$this->assertEquals( $this->inserted_post_id, $result['ID'] );
-
-		// test update attempt - invalid id
-		$request->set_query_params( array( 'id' => 9999 ) );
-		$result = $this->liberate_controller->prepare_item_for_database( $request );
-		$this->assertInstanceOf( 'WP_Error', $result );
 	}
 }

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -1,0 +1,103 @@
+<?php
+
+use DotOrg\TryWordPress\Liberate_Controller;
+use PHPUnit\Framework\TestCase;
+
+class Liberate_Controller_Test extends TestCase {
+	private string $storage_post_type = 'lib_2';
+	private string $date              = '2000-10-25 18:39:03';
+	private string $inserted_post_id;
+	private Liberate_Controller $liberate_controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->liberate_controller = new Liberate_Controller( $this->storage_post_type );
+		$this->inserted_post_id    = wp_insert_post(
+			array(
+				'post_title' => 'hello unit tests',
+			)
+		);
+	}
+
+	public function testGetStoragePostType() {
+		$this->assertEquals( $this->storage_post_type, $this->liberate_controller->get_storage_post_type() );
+	}
+
+	public function testPrepareItemForResponse() {
+		// Note: Not all fields are currently used, so we only look up for fields that we do use
+		// When we start using a new field, this test would fail and require an update :)
+		$post_array = array(
+			'ID'                    => 23,
+			'post_author'           => 42,
+			'post_date'             => $this->date,
+			'post_date_gmt'         => $this->date,
+			'post_content'          => 'This is the test content',
+			'post_title'            => 'This is the test title',
+			'post_excerpt'          => 'This is the test excerpt',
+			'post_status'           => 'publish',
+			'comment_status'        => 'closed',
+			'ping_status'           => 'closed',
+			'post_password'         => '',
+			'post_name'             => '',
+			'to_ping'               => '',
+			'pinged'                => $this->date,
+			'post_modified'         => $this->date,
+			'post_modified_gmt'     => $this->date,
+			'post_content_filtered' => '',
+			'post_parent'           => 0,
+			'guid'                  => 'https://example.org/78',
+			'menu_order'            => 0,
+			'post_type'             => $this->liberate_controller->get_storage_post_type(),
+			'comment_count'         => 0,
+		);
+
+		$result = $this->liberate_controller->prepare_item_for_response(
+			$post_array,
+			new WP_REST_Request()
+		);
+
+		$this->assertEquals(
+			array(
+				'id'        => 23,
+				'authorId'  => 42,
+				'title'     => 'This is the test title',
+				'content'   => 'This is the test content',
+				'date'      => $this->date,
+				'sourceUrl' => 'https://example.org/78',
+			),
+			$result->get_data()
+		);
+	}
+
+	public function testPrepareItemForDatabase() {
+		$request = new WP_REST_Request( 'GET', '/whatever' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'title'     => 'This is the test title',
+					'content'   => 'This is the test content',
+					'sourceUrl' => 'https://example.org/70',
+					'date'      => $this->date,
+				)
+			)
+		);
+
+		// test create attempt
+		$result = $this->liberate_controller->prepare_item_for_database( $request );
+		$this->assertEquals( $this->liberate_controller->get_storage_post_type(), $result['post_type'] );
+		$this->assertEquals( 'This is the test title', $result['post_title'] );
+		$this->assertEquals( 'This is the test content', $result['post_content'] );
+		$this->assertEquals( 'https://example.org/70', $result['guid'] );
+		$this->assertEquals( $this->date, $result['post_date'] );
+
+		// test update attempt - valid id
+		$request->set_query_params( array( 'id' => $this->inserted_post_id ) );
+		$result = $this->liberate_controller->prepare_item_for_database( $request );
+		$this->assertEquals( $this->inserted_post_id, $result['ID'] );
+
+		// test update attempt - invalid id
+		$request->set_query_params( array( 'id' => 9999 ) );
+		$result = $this->liberate_controller->prepare_item_for_database( $request );
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+}

--- a/tests/plugin/test-promoter.php
+++ b/tests/plugin/test-promoter.php
@@ -36,7 +36,7 @@ class Promoter_Test extends TestCase {
 		wp_delete_post( $promoted_post_id, true );
 		wp_delete_post( $this->post_id_in_db, true );
 
-		delete_post_meta( 99, '_promoted_post' );
+		delete_post_meta( 99, '_dl_transformed' );
 	}
 
 	public function testGetPostTypeForPromotedPost() {
@@ -53,7 +53,7 @@ class Promoter_Test extends TestCase {
 	}
 
 	public function testGetPromotedPost() {
-		add_post_meta( 99, '_promoted_post', 999 );
+		add_post_meta( 99, '_dl_transformed', 999 );
 
 		$this->assertEquals( 999, $this->promoter->get_promoted_post_id( 99 ) );
 		$this->assertEquals( null, $this->promoter->get_promoted_post_id( 88 ) );
@@ -62,7 +62,7 @@ class Promoter_Test extends TestCase {
 	public function testPromote(): void {
 		$result = $this->promoter->promote( get_post( $this->post_id_in_db ) );
 
-		$promoted_post_id = absint( get_post_meta( $this->post_id_in_db, '_promoted_post', true ) );
+		$promoted_post_id = absint( get_post_meta( $this->post_id_in_db, '_dl_transformed', true ) );
 
 		$this->assertEquals( $this->post_id_in_db + 1, $promoted_post_id );
 		$this->assertTrue( $result );

--- a/tests/plugin/test-rest-api-extender.php
+++ b/tests/plugin/test-rest-api-extender.php
@@ -56,14 +56,6 @@ class Rest_API_Extender_Test extends TestCase {
 		wp_delete_post( $promoted_post_id, true );
 	}
 
-	public function testRegisterRoute(): void {
-		do_action( 'rest_api_init' ); // so that register_route() executes.
-
-		$routes = rest_get_server()->get_routes( 'wp/v2' );
-
-		$this->assertArrayHasKey( '/wp/v2/lib_x/(?P<id>\d+)/promote', $routes );
-	}
-
 	public function testPromotePost(): void {
 		$request = $this->createMock( WP_REST_Request::class );
 		$request->method( 'offsetGet' )->with( 'id' )->willReturn( $this->post_id_in_db );

--- a/tests/plugin/test-storage.php
+++ b/tests/plugin/test-storage.php
@@ -8,10 +8,10 @@ class Storage_Test extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->storage = new Storage();
+		$this->storage = new Storage( 'lib_x' );
 	}
 
 	public function testRegisterPostTypes(): void {
-		$this->assertTrue( post_type_exists( 'liberated_data' ), 'Custom post type "liberated_data" not registered' );
+		$this->assertTrue( post_type_exists( 'lib_x' ), 'Custom post type meant for storage not registered' );
 	}
 }


### PR DESCRIPTION
This PR is the successor of #85 in which after simplifying the types, we simplify the backend by defining our own custom endpoints with flat object structures rather than fiddling with extending the existing one with more fields and some meta fields.

This way, all WordPress-y bits are abstracted away from the frontend and its contained on the PHP side. This would also remove some of the PHP code and simplifies things once the frontend switches over to use the new custom endpoints.

But before it does, we need to define the api, which is being done in #86 It would also warrant some more changes in our custom endpoints built in this PR.

Finally, since its hard to define a finish line for this PR with other changes being pending, I think just having the custom endpoints up is what I will strive to have as the goal for this PR. 