### PR TITLE
Update @wp-playground/client to latest version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "rules": {
         // Turn on errors for missing imports.
         "import/no-unresolved": "error",
+        "import/named": "off",
         "no-console": [
             "off"
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"dependencies": {
 				"@wordpress/block-library": "^9.7.0",
 				"@wordpress/blocks": "^13.7.0",
-				"@wp-playground/client": "^0.9.46",
+				"@wp-playground/client": "^1.0.8",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-router-dom": "^6.26.1",
@@ -4096,18 +4096,20 @@
 			"license": "MIT"
 		},
 		"node_modules/@php-wasm/fs-journal": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-0.9.46.tgz",
-			"integrity": "sha512-boa0jN0GXhJRAP44Zxz7UsMrPYVUKhUWxdHfG8dzb8dAr1pbD+3pJ8epb0wA/lVaEOEWew/wlCGCbW2yesxQeQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-1.0.8.tgz",
+			"integrity": "sha512-xkX6lJbzUi89bT3bqt0duK4RC1EFiSNbnohcnR7F/TI1ZmAsl4GffKkxM1Y6mVjtAWZKhQJwMo1p10opn9xrlg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/node": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
 				"comlink": "^4.4.1",
+				"events": "3.3.0",
 				"express": "4.19.2",
 				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.0",
 				"yargs": "17.7.2"
 			},
@@ -4117,12 +4119,12 @@
 			}
 		},
 		"node_modules/@php-wasm/logger": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-0.9.46.tgz",
-			"integrity": "sha512-fmDGj7DMA4LVc7eCSxfeUVwwfwo17J9GZchQ76FJK/+I/XSqqiJhE/85TEEgPPpxqeGHpqkXV6S9bGiFmMPHkw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-1.0.8.tgz",
+			"integrity": "sha512-yG+/JsjHSCODqvzcbNTvF9r69S4yZq2eN26WqUJCzgu/8g3QJma2bD7FkKbGDVrMbHxr1uMJESDpYx3Su+E9YQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "0.9.46"
+				"@php-wasm/node-polyfills": "1.0.8"
 			},
 			"engines": {
 				"node": ">=18.18.0",
@@ -4130,20 +4132,22 @@
 			}
 		},
 		"node_modules/@php-wasm/node": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-0.9.46.tgz",
-			"integrity": "sha512-yvI4z148CadV0OVPXGPg4NK/OXj2lnzXWtV13G6I4v5dmzaKNJreIeEQ67KV1dotYD9h0ThaCmGZ62kDUfN1pw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-1.0.8.tgz",
+			"integrity": "sha512-Zlyo7/RcJsXK6gubH6PqIZA30Zhx61MrSDr0h8lErpcYion+Qgs/JqRq4ac40RMYXkP+T+q7EvxKpNORv11HCg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/node-polyfills": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
-				"@wp-playground/common": "0.9.46",
-				"@wp-playground/wordpress": "0.9.46",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node-polyfills": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
+				"@wp-playground/common": "1.0.8",
+				"@wp-playground/wordpress": "1.0.8",
 				"comlink": "^4.4.1",
+				"events": "3.3.0",
 				"express": "4.19.2",
 				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.0",
 				"yargs": "17.7.2"
 			},
@@ -4153,56 +4157,46 @@
 			}
 		},
 		"node_modules/@php-wasm/node-polyfills": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-0.9.46.tgz",
-			"integrity": "sha512-pX0cpMM49dc+e0bPb7X+D7ZrQBd+l5GMesQ5fj/JG/XIUOR6O/CSLtJYK3Se5hUOq5D7UIDhsenEkN1xR5eoWQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-1.0.8.tgz",
+			"integrity": "sha512-HWcW+4fSgwREpw0n7GvG1ntHLOCy1LUVp0jF1ws5fM8WBwv5IbUND44IEEd8u2Z73To2Me9BA40AjBMnVcW+ZA==",
 			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/@php-wasm/progress": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-0.9.46.tgz",
-			"integrity": "sha512-F5zp8orjZZH7KVCcWyCeZk/i7bh0J4j+TfWyK3XQfBkmIt4Z8K4LWz0HwS5g/7ua6F4A96wNyW+W6DqSxqnvSg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-1.0.8.tgz",
+			"integrity": "sha512-0khx7ohb6Wz2gu2dsdSO/WT8ptXiORS8T7CtFJFLQerkHoVCfjGT+RLtO1xBtUChSwgCZBfStfhFoi19bMntMg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/node-polyfills": "0.9.46"
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node-polyfills": "1.0.8"
 			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
 			}
 		},
-		"node_modules/@php-wasm/scopes": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-0.9.46.tgz",
-			"integrity": "sha512-Ab5OMSqLXGrTKGiMjmROcZuf8qzFhzRLvoVK+dhXI4cCemrKGxftFU5jb8E3Qavta7ii1hDle+1UMoVc22yrvA==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=16.15.1",
-				"npm": ">=8.11.0"
-			}
-		},
 		"node_modules/@php-wasm/stream-compression": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-0.9.46.tgz",
-			"integrity": "sha512-CiBAyRE3vKDB+Nx4f+ZSXjLhreLOs43CRUHv+WCSKFCIFeDfWcEJFhIIrAJr7peHvXN7GBVmAlOxm+TTbmqtRg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-1.0.8.tgz",
+			"integrity": "sha512-cliCA41y8/Ao7nxmCXzsm8o/AIn1P9EgDfO1VpvZKPcEVNrkrErOm13o3al0g3UvWsRmkly2yPdmbkNXcDD1kw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "0.9.46",
-				"@php-wasm/util": "0.9.46"
+				"@php-wasm/node-polyfills": "1.0.8",
+				"@php-wasm/util": "1.0.8"
 			}
 		},
 		"node_modules/@php-wasm/universal": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.9.46.tgz",
-			"integrity": "sha512-Cf/bTExIPvtcCbvHsDB7NdxXsflhiWJj86dXpoCN2SQl2D3YiXCBIBegK646Vv4rCoGh+GhhuwLjzG9v4RbRyA==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-1.0.8.tgz",
+			"integrity": "sha512-Kfuh9Bu2flDxwN1158aG7f304bcj7P9qdz1jVEuk+bzXc1Pas+l0WJBoJAJ+fULmJPMwpd/tFuHDlVQSASga8g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/node-polyfills": "0.9.46",
-				"@php-wasm/progress": "0.9.46",
-				"@php-wasm/stream-compression": "0.9.46",
-				"@php-wasm/util": "0.9.46",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node-polyfills": "1.0.8",
+				"@php-wasm/progress": "1.0.8",
+				"@php-wasm/stream-compression": "1.0.8",
+				"@php-wasm/util": "1.0.8",
 				"comlink": "^4.4.1",
 				"ini": "4.1.2"
 			},
@@ -4212,46 +4206,34 @@
 			}
 		},
 		"node_modules/@php-wasm/util": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-0.9.46.tgz",
-			"integrity": "sha512-Chgtkon+su2IIhsJJrv8nMgk5uYST0Efh19xQ/Hp84jQjMLA0crhiGbpIEHgjeK8MHbd8SytWRrzsnA0DTu4bw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-1.0.8.tgz",
+			"integrity": "sha512-kA0pQ6kGO+IS6XanbGfxYxhKSUzQna+HL1lKsy6/Pz5842ereV19rKyEYHAeafL1djldF3B7tkQO5MOjBrT5fg==",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
 			}
 		},
 		"node_modules/@php-wasm/web": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-0.9.46.tgz",
-			"integrity": "sha512-/wk6yf8CRaakMJ6r/oX/vFo858yFqK5Iqf3/Lxuq0n06Yp5NnEN0krRHWn6PKNMqnpax3xr+XO2Xg/jmXjKJPg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-1.0.8.tgz",
+			"integrity": "sha512-49BsZjat31falPRRaCTgOEc0aSZ8DLJwULOIVvDcdU6BETPaKqMRRNLHYwMH6FyhVAnSFvxr5uIpGp3sjynbkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/fs-journal": "0.9.46",
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
-				"@php-wasm/web-service-worker": "0.9.46",
+				"@php-wasm/fs-journal": "1.0.8",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
 				"comlink": "^4.4.1",
+				"events": "3.3.0",
 				"express": "4.19.2",
 				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.0",
 				"yargs": "17.7.2"
 			},
 			"engines": {
 				"node": ">=16.15.1",
-				"npm": ">=8.11.0"
-			}
-		},
-		"node_modules/@php-wasm/web-service-worker": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-0.9.46.tgz",
-			"integrity": "sha512-USWTUW1KhEYfkuY2A6WBT7YVCIbINwcgZefi66N3hkofjGXeLUhFPhvMd4hcjFCUASkpoUFAP0di3MfLZRhvGA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/scopes": "0.9.46"
-			},
-			"engines": {
-				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -10065,58 +10047,188 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-0.9.46.tgz",
-			"integrity": "sha512-Fe6+xqHe0NpH0RATpVHjEw4wtFB3UB1OaZx89+FSUlFNjYVb5WlJjCOqDCzoN50BEz1Abs5x1ZQKVKBo82sTbQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-1.0.8.tgz",
+			"integrity": "sha512-wSQ1tMHPjESFoFNJX+O4LScjpLfnSEDRChq3iLPjoHAJoN8r34P+4C7cQ4U3fdudvuXonmizpFYfYI/9LMAZIA==",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/node": "0.9.46",
-				"@php-wasm/node-polyfills": "0.9.46",
-				"@php-wasm/progress": "0.9.46",
-				"@php-wasm/scopes": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
-				"@wp-playground/common": "0.9.46",
-				"@wp-playground/wordpress": "0.9.46",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node": "1.0.8",
+				"@php-wasm/node-polyfills": "1.0.8",
+				"@php-wasm/progress": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
+				"@wp-playground/common": "1.0.8",
+				"@wp-playground/storage": "1.0.8",
+				"@wp-playground/wordpress": "1.0.8",
 				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"buffer": "6.0.3",
+				"clean-git-ref": "2.0.1",
 				"comlink": "^4.4.1",
-				"ini": "4.1.2"
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"ignore": "5.2.4",
+				"ini": "4.1.2",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.1",
+				"pako": "1.0.10",
+				"pify": "5.0.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.11",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/@wp-playground/blueprints/node_modules/pify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+			"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@wp-playground/client": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-0.9.46.tgz",
-			"integrity": "sha512-eNLXCIu6zcHEhJ2GMGVXaA0cLjCH627mrfiIWj+vszjo1cwj3/oaBKIzG6ArNkOU+wiK0GskMC00BZwKDbxUNw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-1.0.8.tgz",
+			"integrity": "sha512-xCEZbgWMkTb869HFmDD2/uMpRKjetptfJ4dnjrQso4xUjqeVhCVphnRYEfHePamIO2xY/m2fbEfDHENMc+rjgw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "0.9.46",
-				"@php-wasm/progress": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
-				"@php-wasm/web": "0.9.46",
-				"@wp-playground/blueprints": "0.9.46",
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/progress": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
+				"@php-wasm/web": "1.0.8",
+				"@wp-playground/blueprints": "1.0.8",
+				"@wp-playground/remote": "1.0.8",
 				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"buffer": "6.0.3",
+				"clean-git-ref": "2.0.1",
 				"comlink": "^4.4.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"ignore": "5.2.4",
 				"ini": "4.1.2",
-				"octokit": "3.1.1"
+				"minimisted": "2.0.1",
+				"octokit": "3.1.1",
+				"pako": "1.0.10",
+				"pify": "5.0.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.11",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
 			}
 		},
+		"node_modules/@wp-playground/client/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@wp-playground/client/node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@wp-playground/client/node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/@wp-playground/client/node_modules/pify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+			"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@wp-playground/common": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-0.9.46.tgz",
-			"integrity": "sha512-ORkT2oPYtIrq5YQusl22yXsoi7Ma6tvnUMOjxW68AYN0/6E5mCCxMK3xU56WcgLXV5CAXEtJ8yVipJZwl4l1CQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-1.0.8.tgz",
+			"integrity": "sha512-/kNVI8c3LhCkA5wZZBk7n/JAzpyVi/HDRECbSvMQT/KrB5FufjuJv1WBH8I1EYf8KqSSvGxdmWIQjWeCzv8oQg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
 				"comlink": "^4.4.1",
 				"ini": "4.1.2"
 			},
@@ -10125,19 +10237,89 @@
 				"npm": ">=8.11.0"
 			}
 		},
-		"node_modules/@wp-playground/wordpress": {
-			"version": "0.9.46",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-0.9.46.tgz",
-			"integrity": "sha512-emBgcs2ZvxLcNh9CJicAzkS+9zzQjc0SftTb/7l7tO8c1p9p4t3qyefQdQMniji8qywBJ9v9eYe+3+ZLYWaQ1Q==",
+		"node_modules/@wp-playground/remote": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/remote/-/remote-1.0.8.tgz",
+			"integrity": "sha512-RC66lDOeV8hPEEG3iXLXVJ3RdSrzz5IXl6YP/pxDIWSSV48oGwteaG28ElbGmxGYbHRCZuZ+0FZRkKBFAjdSkQ==",
+			"license": "GPL-2.0-or-later"
+		},
+		"node_modules/@wp-playground/storage": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-1.0.8.tgz",
+			"integrity": "sha512-hAGdeEyeMkvlV9hfruUSrL88eUPunMyhBLydthSvT/Udgrt4zhCRbCiq03x4BOhpL1xhLlGaEPvqwoU/cddHMg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node": "0.9.46",
-				"@php-wasm/universal": "0.9.46",
-				"@php-wasm/util": "0.9.46",
-				"@wp-playground/common": "0.9.46",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
+				"@php-wasm/web": "1.0.8",
+				"async-lock": "^1.4.1",
+				"buffer": "6.0.3",
+				"clean-git-ref": "^2.0.1",
 				"comlink": "^4.4.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"events": "3.3.0",
+				"express": "4.19.2",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.1",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0",
+				"yargs": "17.7.2"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/wordpress": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-1.0.8.tgz",
+			"integrity": "sha512-rF3gPuwdQDif8O5CrV9OznN6P8WmmuMBCXfvu91xMoVJH8iIXxtz2MGj3HT7SNQ0gDzbADf1I9DL9zw0dYKBHA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "1.0.8",
+				"@php-wasm/node": "1.0.8",
+				"@php-wasm/universal": "1.0.8",
+				"@php-wasm/util": "1.0.8",
+				"@wp-playground/common": "1.0.8",
+				"comlink": "^4.4.1",
+				"events": "3.3.0",
 				"express": "4.19.2",
 				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.0",
 				"yargs": "17.7.2"
 			},
@@ -11159,6 +11341,12 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
 			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
 			"license": "MIT"
 		},
 		"node_modules/asynckit": {
@@ -12596,6 +12784,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -13432,7 +13626,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
 			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"crc32": "bin/crc32.njs"
@@ -14114,7 +14307,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
 			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
@@ -14130,7 +14322,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
 			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -14665,6 +14856,12 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
+		},
+		"node_modules/diff3": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -18618,7 +18815,6 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -23445,7 +23641,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -23484,6 +23679,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5"
 			}
 		},
 		"node_modules/minipass": {
@@ -24909,7 +25113,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/param-case": {
@@ -25142,7 +25345,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -27961,7 +28163,6 @@
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
 				"inherits": "^2.0.1",
@@ -28266,6 +28467,51 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
 		},
 		"node_modules/simple-html-tokenizer": {
 			"version": "0.5.11",
@@ -31089,6 +31335,12 @@
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
+		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/watchpack": {
 			"version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"dependencies": {
 		"@wordpress/block-library": "^9.7.0",
 		"@wordpress/blocks": "^13.7.0",
-		"@wp-playground/client": "^0.9.46",
+		"@wp-playground/client": "^1.0.8",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-router-dom": "^6.26.1",

--- a/src/ui/blueprints/EditBlueprint.tsx
+++ b/src/ui/blueprints/EditBlueprint.tsx
@@ -92,7 +92,7 @@ export function EditBlueprint() {
 				postFieldsToUpdate
 			);
 			setPost( p );
-			void playgroundClient.goTo( '/?p=' + post.transformedId );
+			void playgroundClient!.goTo( '/?p=' + post.transformedId );
 		}
 	}
 

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -16,7 +16,6 @@ export function Playground( props: {
 	onReady: ( client: PlaygroundClient ) => void;
 } ) {
 	const { slug, className, blogName, onReady } = props;
-
 	const initializationRef = useRef( false );
 
 	useEffect( () => {

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -55,6 +55,8 @@ async function initPlayground(
 	slug: string,
 	blogName: string
 ): Promise< PlaygroundClient > {
+	// TODO: We should pass the initialSyncDirection property.
+	// @ts-ignore
 	const mountDescriptor: MountDescriptor = {
 		device: {
 			type: 'opfs',


### PR DESCRIPTION
The latest version (1.0.8) fixes [issues with missing types](https://github.com/WordPress/wordpress-playground/issues/1725).