### PR TITLE
Add navigation support

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -1,4 +1,5 @@
 import { PlaygroundClient } from '@wp-playground/client';
+import { NavigationApi } from '@/api/Navigation';
 import { BlogPostsApi } from '@/api/BlogPosts';
 import { PagesApi } from '@/api/Pages';
 import { SettingsApi } from '@/api/Settings';
@@ -8,6 +9,7 @@ import { BlueprintsApi } from '@/api/Blueprints';
 export class ApiClient {
 	private readonly playgroundClient: PlaygroundClient;
 	private readonly _siteUrl: string;
+	private readonly _navigation: NavigationApi;
 	private readonly _blogPosts: BlogPostsApi;
 	private readonly _pages: PagesApi;
 	private readonly _settings: SettingsApi;
@@ -18,6 +20,7 @@ export class ApiClient {
 		this.playgroundClient = playgroundClient;
 		this._siteUrl = siteUrl;
 		this._blueprints = new BlueprintsApi( this );
+		this._navigation = new NavigationApi( this );
 		this._blogPosts = new BlogPostsApi( this );
 		this._pages = new PagesApi( this );
 		this._settings = new SettingsApi( this );
@@ -34,6 +37,10 @@ export class ApiClient {
 
 	get blogPosts(): BlogPostsApi {
 		return this._blogPosts;
+	}
+
+	get navigation(): NavigationApi {
+		return this._navigation;
 	}
 
 	get pages(): PagesApi {

--- a/src/api/Navigation.ts
+++ b/src/api/Navigation.ts
@@ -1,0 +1,87 @@
+import { Navigation } from '@/model/subject/Navigation';
+import { ApiClient } from '@/api/ApiClient';
+import { SubjectType } from '@/model/subject/Subject';
+import { HtmlField, newHtmlField } from '@/model/field/HtmlField';
+import { ApiPost } from '@/api/ApiTypes';
+
+interface UpdateBody {
+	content?: HtmlField;
+}
+
+interface PostMeta {
+	guid: string;
+	raw_content: string;
+}
+
+export class NavigationApi {
+	// eslint-disable-next-line no-useless-constructor
+	constructor( private readonly client: ApiClient ) {}
+
+	async create( navigation: Navigation ): Promise< Navigation > {
+		const response = ( await this.client.post( '/liberated_data_navigation', {
+			meta: {
+				guid: navigation.sourceUrl,
+			},
+		} ) ) as ApiPost;
+		return fromApiResponse( response );
+	}
+
+	async update( id: number, body: UpdateBody ): Promise< Navigation > {
+		const actualBody: any = {};
+		if ( body.content ) {
+			actualBody.meta = {};
+		}
+		if ( body.content ) {
+			actualBody.content = body.content.parsed;
+			actualBody.meta.raw_content = body.content.original;
+		}
+		if ( Object.keys( actualBody ).length === 0 ) {
+			throw Error( 'attempting to update zero fields' );
+		}
+		const response = ( await this.client.post(
+			`/liberated_data_navigation/${ id }`,
+			actualBody
+		) ) as ApiPost;
+		return fromApiResponse( response );
+	}
+
+	async findById( id: string ): Promise< Navigation | null > {
+		// eslint-disable-next-line react/no-is-mounted
+		const posts = await this.find( { id } );
+		return posts.length === 0 ? null : fromApiResponse( posts[ 0 ] );
+	}
+
+	async findBySourceUrl( sourceUrl: string ): Promise< Navigation | null > {
+		// eslint-disable-next-line react/no-is-mounted
+		const posts = await this.find( { guid: sourceUrl } );
+		return posts.length === 0 ? null : fromApiResponse( posts[ 0 ] );
+	}
+
+	private async find(
+		params: Record< string, string >
+	): Promise< ApiPost[] > {
+		params.status = 'draft';
+		// Must set context to 'edit' to have all fields in the response.
+		params.context = 'edit';
+		return ( await this.client.get(
+			`/liberated_data_navigation`,
+			params
+		) ) as ApiPost[];
+	}
+}
+
+function fromApiResponse( response: ApiPost ): Navigation {
+	const meta = response.meta as unknown as PostMeta;
+	const content = newHtmlField(
+		meta.raw_content,
+		response.content.raw ?? ''
+	);
+
+	return {
+		type: SubjectType.Navigation,
+		sourceUrl: meta.guid,
+		id: response.id,
+		transformedId: response.transformed_id,
+		content,
+	};
+}

--- a/src/model/blueprint/Navigation.ts
+++ b/src/model/blueprint/Navigation.ts
@@ -1,0 +1,38 @@
+import { SubjectType } from '@/model/subject/Subject';
+import { FieldType } from '@/model/field/Field';
+import { Blueprint } from '@/model/blueprint/Blueprint';
+
+export interface NavigationBlueprint extends Blueprint {
+	type: SubjectType.Navigation;
+	fields: {
+		content: { type: FieldType.Html; selector?: string };
+	};
+}
+
+export function newNavigationBlueprint( sourceUrl: string ): NavigationBlueprint {
+	return {
+		id: '',
+		type: SubjectType.Navigation,
+		sourceUrl,
+		valid: false,
+		fields: {
+			content: {
+				type: FieldType.Html,
+				selector: '',
+			},
+		},
+	};
+}
+
+export function validateNavigationBlueprint(
+	blueprint: NavigationBlueprint
+): boolean {
+	let isValid = true;
+	for ( const f of Object.values( blueprint.fields ) ) {
+		if ( f.selector === '' ) {
+			isValid = false;
+			break;
+		}
+	}
+	return isValid;
+}

--- a/src/model/subject/Navigation.ts
+++ b/src/model/subject/Navigation.ts
@@ -1,0 +1,29 @@
+import { Subject, SubjectType } from '@/model/subject/Subject';
+import { HtmlField, newHtmlField } from '@/model/field/HtmlField';
+
+export interface Navigation extends Subject {
+	type: SubjectType.Navigation;
+	content: HtmlField;
+}
+
+export function newNavigation( sourceUrl: string ): Navigation {
+	return {
+		id: 0,
+		transformedId: 0,
+		type: SubjectType.Navigation,
+		sourceUrl,
+		content: newHtmlField(),
+	};
+}
+
+export function validateNavigation( navigation: Navigation ): boolean {
+	const fields = [ navigation.content ];
+	let isValid = true;
+	for ( const f of fields ) {
+		if ( f.original === '' || f.parsed === '' ) {
+			isValid = false;
+			break;
+		}
+	}
+	return isValid;
+}

--- a/src/model/subject/Subject.ts
+++ b/src/model/subject/Subject.ts
@@ -1,9 +1,11 @@
 export enum SubjectType {
+	Navigation = 'navigation',
 	BlogPost = 'blog-post',
 	Page = 'page',
 }
 
 export const humanReadableSubjectType: Map< SubjectType, string > = new Map( [
+	[ SubjectType.Navigation, 'Navigation' ],
 	[ SubjectType.BlogPost, 'Blog Post' ],
 	[ SubjectType.Page, 'Page' ],
 ] );

--- a/src/parser/navigation.ts
+++ b/src/parser/navigation.ts
@@ -1,0 +1,25 @@
+import { pasteHandler, serialize } from '@wordpress/blocks';
+import { findDeepestChild } from '@/parser/util';
+import { HtmlField, newHtmlField } from '@/model/field/HtmlField';
+import { Field } from '@/model/field/Field';
+
+export function parseNavigationField( name: string, field: Field ): Field {
+	switch ( name ) {
+		case 'navigation':
+			return parseNavigation( field.original );
+		default:
+			throw Error( `unknown field type ${ field.type }` );
+	}
+}
+
+export function parseNavigation( html: string ): HtmlField {
+	return newHtmlField( html, serializeBlocks( html ) );
+}
+
+function serializeBlocks( html: string ): string {
+	const blocks = pasteHandler( {
+		mode: 'BLOCKS',
+		HTML: html,
+	} );
+	return serialize( blocks );
+}

--- a/src/ui/blueprints/EditBlueprint.tsx
+++ b/src/ui/blueprints/EditBlueprint.tsx
@@ -1,9 +1,11 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { ReactElement, useEffect } from 'react';
 import { useSessionContext } from '@/ui/session/SessionProvider';
+import { NavigationBlueprintEditor } from '@/ui/blueprints/blog-post/NavigationBlueprintEditor';
 import { BlogPostBlueprintEditor } from '@/ui/blueprints/blog-post/BlogPostBlueprintEditor';
 import { PageBlueprintEditor } from '@/ui/blueprints/blog-post/PageBlueprintEditor';
 import { Toolbar } from '@/ui/blueprints/Toolbar';
+import { parseNavigationField } from '@/parser/navigation';
 import { parseBlogPostField } from '@/parser/blog-post';
 import { parsePageField } from '@/parser/page';
 import { SubjectType } from '@/model/subject/Subject';
@@ -16,6 +18,11 @@ import {
 	BlogPostBlueprint,
 	validateBlogpostBlueprint,
 } from '@/model/blueprint/BlogPost';
+import { Navigation, validateNavigation } from '@/model/subject/Navigation';
+import {
+	NavigationBlueprint,
+	validateNavigationBlueprint,
+} from '@/model/blueprint/Navigation';
 import { Page, validatePage } from '@/model/subject/Page';
 import {
 	PageBlueprint,
@@ -62,6 +69,15 @@ export function EditBlueprint() {
 
 		const subjectFieldsToUpdate: Record< string, Field > = {};
 		switch ( subject.type ) {
+			case SubjectType.Navigation:
+				blueprint.valid = validateNavigationBlueprint(
+					blueprint as NavigationBlueprint
+				);
+				subjectFieldsToUpdate[ name ] = parseNavigationField(
+					name,
+					field
+				);
+				break;
 			case SubjectType.BlogPost:
 				blueprint.valid = validateBlogpostBlueprint(
 					blueprint as BlogPostBlueprint
@@ -100,6 +116,16 @@ export function EditBlueprint() {
 
 	if ( blueprint && subject ) {
 		switch ( subject.type ) {
+			case SubjectType.Navigation:
+				isValid = validateNavigation( subject as Navigation );
+				editor = (
+					<NavigationBlueprintEditor
+						blueprint={ blueprint as NavigationBlueprint }
+						subject={ subject as Navigation }
+						onFieldChanged={ onFieldChanged }
+					/>
+				);
+				break;
 			case SubjectType.BlogPost:
 				isValid = validateBlogPost( subject as BlogPost );
 				editor = (

--- a/src/ui/blueprints/NewBlueprint.tsx
+++ b/src/ui/blueprints/NewBlueprint.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Screens } from '@/ui/App';
 import { Toolbar } from '@/ui/blueprints/Toolbar';
 import { humanReadableSubjectType, SubjectType } from '@/model/subject/Subject';
+import { newNavigationBlueprint } from '@/model/blueprint/Navigation';
 import { newBlogPostBlueprint } from '@/model/blueprint/BlogPost';
 import { newPageBlueprint } from '@/model/blueprint/Page';
 import { Blueprint } from '@/model/blueprint/Blueprint';
@@ -43,7 +44,7 @@ export function NewBlueprint() {
 		maybeRedirect().catch( console.error );
 	}, [ session.id, apiClient, subjectType, navigate ] );
 
-	const navigateMessage = (
+	let navigateMessage = (
 		<>
 			Navigate to the page of a{ ' ' }
 			{ humanReadableSubjectType.get( subjectType ) }
@@ -61,6 +62,17 @@ export function NewBlueprint() {
 						} ) ) as CurrentPageInfo;
 						let blueprint: Blueprint | null;
 						switch ( subjectType ) {
+							case SubjectType.Navigation:
+								navigateMessage = (
+									<>
+										Please navigate to the page that you would like to
+										extract the navigation from.
+									</>
+								);
+								blueprint = await apiClient!.blueprints.create(
+									newNavigationBlueprint( currentPage.url )
+								);
+								break;
 							case SubjectType.BlogPost:
 								blueprint = await apiClient!.blueprints.create(
 									newBlogPostBlueprint( currentPage.url )

--- a/src/ui/blueprints/blog-post/NavigationBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/NavigationBlueprintEditor.tsx
@@ -1,0 +1,100 @@
+import { ReactElement, useEffect, useState } from 'react';
+import { FieldEditor } from '@/ui/blueprints/FieldEditor';
+import { Field } from '@/model/field/Field';
+import { Navigation } from '@/model/subject/Navigation';
+import { NavigationBlueprint } from '@/model/blueprint/Navigation';
+import { CommandTypes, sendCommandToContent } from '@/bus/Command';
+import { EventTypes } from '@/bus/Event';
+import { ContentEventHandler } from '@/ui/blueprints/ContentEventHandler';
+
+interface Props {
+	blueprint: NavigationBlueprint;
+	subject: Navigation;
+	onFieldChanged: ( name: string, field: Field, selector: string ) => void;
+}
+
+export function NavigationBlueprintEditor( props: Props ) {
+	const { blueprint, subject, onFieldChanged } = props;
+	const [ fieldWaitingForSelection, setFieldWaitingForSelection ] = useState<
+		false | { field: Field; name: string }
+	>( false );
+
+	const subjectFields: { name: string; field: Field }[] = [
+		{ name: 'content', field: subject.content },
+	];
+
+	// Enable or disable highlighting according to whether a field is waiting for selection.
+	useEffect( () => {
+		const type =
+			fieldWaitingForSelection === false
+				? CommandTypes.DisableHighlighting
+				: CommandTypes.EnableHighlighting;
+		void sendCommandToContent( { type, payload: {} } );
+	}, [ fieldWaitingForSelection ] );
+
+	const elements: ReactElement[] = [];
+	for ( const { name, field } of subjectFields ) {
+		const isWaitingForSelection =
+			!! fieldWaitingForSelection &&
+			fieldWaitingForSelection.name === name;
+
+		const blueprintField =
+			blueprint.fields[ name as keyof typeof blueprint.fields ];
+		if ( ! blueprintField ) {
+			throw new Error( `blueprint field ${ name } not found` );
+		}
+
+		elements.push(
+			<FieldEditor
+				key={ name }
+				label={ name }
+				blueprintField={ blueprintField }
+				field={ field }
+				waitingForSelection={ isWaitingForSelection }
+				onWaitingForSelection={ async ( f: Field | false ) => {
+					if ( f === false ) {
+						setFieldWaitingForSelection( false );
+					} else {
+						setFieldWaitingForSelection( { field: f, name } );
+					}
+				} }
+				onClear={ async () => {
+					field.original = '';
+					field.parsed = '';
+					onFieldChanged( name, field, '' );
+				} }
+			/>
+		);
+	}
+
+	return (
+		<>
+			{ /*
+			Handle a click on an element in the content script,
+			according to which field is currently waiting for selection.
+			*/ }
+			<ContentEventHandler
+				eventType={ EventTypes.OnElementClick }
+				onEvent={ async ( event ) => {
+					if ( fieldWaitingForSelection === false ) {
+						console.warn(
+							'Received an OnElementClick event but no field is waiting for selection'
+						);
+						return;
+					}
+					const selector = 'TODO';
+					fieldWaitingForSelection.field.original = (
+						event.event.payload as any
+					 ).content;
+					onFieldChanged(
+						fieldWaitingForSelection.name,
+						fieldWaitingForSelection.field,
+						selector
+					);
+					setFieldWaitingForSelection( false );
+				} }
+			/>
+			{ elements }
+		</>
+	);
+}

--- a/src/ui/blueprints/useSubjectForBlueprint.ts
+++ b/src/ui/blueprints/useSubjectForBlueprint.ts
@@ -2,6 +2,7 @@ import { Blueprint } from '@/model/blueprint/Blueprint';
 import { Subject, SubjectType } from '@/model/subject/Subject';
 import { useEffect, useState } from 'react';
 import { useSessionContext } from '@/ui/session/SessionProvider';
+import { newNavigation } from '@/model/subject/Navigation';
 import { newBlogPost } from '@/model/subject/BlogPost';
 import { newPage } from '@/model/subject/Page';
 
@@ -21,6 +22,11 @@ export function useSubjectForBlueprint(
 		async function loadSubject( bp: Blueprint ) {
 			let subj: Subject | null;
 			switch ( bp.type ) {
+				case SubjectType.Navigation:
+					subj = await apiClient!.navigation.findBySourceUrl(
+						bp.sourceUrl
+					);
+					break;
 				case SubjectType.BlogPost:
 					subj = await apiClient!.blogPosts.findBySourceUrl(
 						bp.sourceUrl
@@ -36,6 +42,11 @@ export function useSubjectForBlueprint(
 			}
 			if ( ! subj ) {
 				switch ( bp.type ) {
+					case SubjectType.Navigation:
+						subj = await apiClient!.navigation.create(
+							newNavigation( bp.sourceUrl )
+						);
+						break;
 					case SubjectType.BlogPost:
 						subj = await apiClient!.blogPosts.create(
 							newBlogPost( bp.sourceUrl )

--- a/src/ui/session/ViewSession.tsx
+++ b/src/ui/session/ViewSession.tsx
@@ -19,6 +19,19 @@ export function ViewSession() {
 							navigate(
 								Screens.blueprints.new(
 									session.id,
+									SubjectType.Navigation
+								)
+							)
+						}
+					>
+						Import Navigation
+					</button>
+				</li>				<li>
+					<button
+						onClick={ () =>
+							navigate(
+								Screens.blueprints.new(
+									session.id,
 									SubjectType.BlogPost
 								)
 							)


### PR DESCRIPTION
This adds a navigation post type.  Unfortunately currently broken with the error:

> [07-Nov-2024 17:11:09 UTC] PHP Notice:  Function register_post_type was called <strong>incorrectly</strong>. Post type names must be between 1 and 20 characters in length. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 4.2.0.) in /wordpress/wp-includes/functions.php on line 135

![Screenshot 2024-11-07 at 18 07 36](https://github.com/user-attachments/assets/7d3c6483-b63c-4c33-a536-ef9f7adadacf)
