### PR TITLE
Introduce unique constraint on `sourceUrl`

### DIFF
--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -195,6 +195,11 @@ class Blogpost_Controller extends Liberate_Controller {
 	}
 
 	public function create_item( $request ): WP_REST_Response|WP_Error {
+		$valid_request_for_insert = $this->valid_request_for_insert( $request );
+		if ( is_wp_error( $valid_request_for_insert ) ) {
+			return $valid_request_for_insert;
+		}
+
 		$item      = $this->prepare_item_for_database( $request );
 		$item_meta = $item['meta'];
 		unset( $item['meta'] );

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -271,7 +271,7 @@ class Blogpost_Controller extends Liberate_Controller {
 		}
 
 		$post_id = $this->get_post_id_by_guid( $guid );
-		
+
 		if ( $post_id ) {
 			$post = get_post( $post_id, ARRAY_A );
 			return $this->prepare_item_for_response( $post, $request );

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -270,35 +270,10 @@ class Blogpost_Controller extends Liberate_Controller {
 			);
 		}
 
-		// Use wp_cache_* for guid -> postId
-		$cache_group = 'try_wp';
-		$cache_key   = 'try_wp_cache_guid_' . md5( $guid );
-		$post_id     = wp_cache_get( $cache_key, $cache_group );
-
-		if ( false !== $post_id ) {
-			// Cache hit - get post using WordPress API
+		$post_id = $this->get_post_id_by_guid( $guid );
+		
+		if ( $post_id ) {
 			$post = get_post( $post_id, ARRAY_A );
-			if ( $post ) {
-				return $this->prepare_item_for_response( $post, $request );
-			}
-			// If post not found despite cache hit, delete the cache
-			wp_cache_delete( $cache_key, $cache_group );
-		}
-
-		// Cache miss - query database
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$post = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT * FROM $wpdb->posts WHERE guid = %s",
-				$guid
-			),
-			ARRAY_A
-		);
-
-		if ( $post ) {
-			// Cache the post ID for future lookups
-			wp_cache_set( $cache_key, $post['ID'], $cache_group, YEAR_IN_SECONDS );
 			return $this->prepare_item_for_response( $post, $request );
 		}
 

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -24,7 +24,7 @@ class Liberate_Controller extends WP_REST_Controller {
 
 	public function valid_request_for_insert( $request ): bool|WP_Error {
 		$request_data = json_decode( $request->get_body(), true );
-		$guid        = $request_data['sourceUrl']; // required arg, will always be present at this point
+		$guid         = $request_data['sourceUrl']; // required arg, will always be present at this point
 
 		// Rule1: guid must be unique
 		$post_id = $this->get_post_id_by_guid( $guid );

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -22,6 +22,31 @@ class Liberate_Controller extends WP_REST_Controller {
 		return $this->storage_post_type;
 	}
 
+	public function valid_request_for_insert( $request ): bool|WP_Error {
+		global $wpdb;
+
+		$request_data = json_decode( $request->get_body(), true );
+		$guid         = $request_data['sourceUrl']; // required arg, will always be present at this point
+
+		// Rule1: guid must be unique
+		$post = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE guid = %s;",
+				$guid
+			)
+		);
+
+		if ( $post ) {
+			return new WP_Error(
+				'rest_source_url_not_unique',
+				__( 'Source URL specified already exists', 'try_wordpress' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return true;
+	}
+
 	public function valid_request_for_update( $request ): bool|WP_Error {
 		// Rule1: post id must be a valid id
 		$post_id = $request['id'];

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -23,20 +23,13 @@ class Liberate_Controller extends WP_REST_Controller {
 	}
 
 	public function valid_request_for_insert( $request ): bool|WP_Error {
-		global $wpdb;
-
 		$request_data = json_decode( $request->get_body(), true );
-		$guid         = $request_data['sourceUrl']; // required arg, will always be present at this point
+		$guid        = $request_data['sourceUrl']; // required arg, will always be present at this point
 
 		// Rule1: guid must be unique
-		$post = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT ID FROM {$wpdb->posts} WHERE guid = %s;",
-				$guid
-			)
-		);
+		$post_id = $this->get_post_id_by_guid( $guid );
 
-		if ( $post ) {
+		if ( $post_id ) {
 			return new WP_Error(
 				'rest_source_url_not_unique',
 				__( 'Source URL specified already exists', 'try_wordpress' ),

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -86,7 +86,7 @@ class Liberate_Controller extends WP_REST_Controller {
 		);
 
 		// Bust guid -> postId cache when a post is deleted
-		add_filter(
+		add_action(
 			'delete_post_' . $this->storage_post_type,
 			function ( $post_id, $post ) {
 				$cache_group = 'try_wp';

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -163,4 +163,39 @@ class Liberate_Controller extends WP_REST_Controller {
 
 		return $prepared_post;
 	}
+
+	public function get_post_id_by_guid( string $guid ): ?int {
+		// Use wp_cache_* for guid -> postId
+		$cache_group = 'try_wp';
+		$cache_key   = 'try_wp_cache_guid_' . md5( $guid );
+		$post_id     = wp_cache_get( $cache_key, $cache_group );
+
+		if ( false !== $post_id ) {
+			// Cache hit - get post using WordPress API
+			$post = get_post( $post_id );
+			if ( $post ) {
+				return (int) $post_id;
+			}
+			// If post not found despite cache hit, delete the cache
+			wp_cache_delete( $cache_key, $cache_group );
+		}
+
+		// Cache miss - query database
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID FROM $wpdb->posts WHERE guid = %s",
+				$guid
+			)
+		);
+
+		if ( $post_id ) {
+			// Cache the post ID for future lookups
+			wp_cache_set( $cache_key, $post_id, $cache_group, YEAR_IN_SECONDS );
+			return (int) $post_id;
+		}
+
+		return null;
+	}
 }

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -23,7 +23,7 @@ class Liberate_Controller extends WP_REST_Controller {
 	}
 
 	public function valid_request_for_update( $request ): bool|WP_Error {
-		// Rule1: if post id is specified, it must be a valid id
+		// Rule1: post id must be a valid id
 		$post_id = $request['id'];
 		$item    = get_post( $post_id );
 		if ( is_null( $item ) ) {

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -195,6 +195,11 @@ class Page_Controller extends Liberate_Controller {
 	}
 
 	public function create_item( $request ): WP_REST_Response|WP_Error {
+		$valid_request_for_insert = $this->valid_request_for_insert( $request );
+		if ( is_wp_error( $valid_request_for_insert ) ) {
+			return $valid_request_for_insert;
+		}
+
 		$item      = $this->prepare_item_for_database( $request );
 		$item_meta = $item['meta'];
 		unset( $item['meta'] );

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -270,35 +270,10 @@ class Page_Controller extends Liberate_Controller {
 			);
 		}
 
-		// Use wp_cache_* for guid -> postId
-		$cache_group = 'try_wp';
-		$cache_key   = 'try_wp_cache_guid_' . md5( $guid );
-		$post_id     = wp_cache_get( $cache_key, $cache_group );
-
-		if ( false !== $post_id ) {
-			// Cache hit - get post using WordPress API
+		$post_id = $this->get_post_id_by_guid( $guid );
+		
+		if ( $post_id ) {
 			$post = get_post( $post_id, ARRAY_A );
-			if ( $post ) {
-				return $this->prepare_item_for_response( $post, $request );
-			}
-			// If post not found despite cache hit, delete the cache
-			wp_cache_delete( $cache_key, $cache_group );
-		}
-
-		// Cache miss - query database
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$post = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT * FROM $wpdb->posts WHERE guid = %s",
-				$guid
-			),
-			ARRAY_A
-		);
-
-		if ( $post ) {
-			// Cache the post ID for future lookups
-			wp_cache_set( $cache_key, $post['ID'], $cache_group, YEAR_IN_SECONDS );
 			return $this->prepare_item_for_response( $post, $request );
 		}
 

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -271,7 +271,7 @@ class Page_Controller extends Liberate_Controller {
 		}
 
 		$post_id = $this->get_post_id_by_guid( $guid );
-		
+
 		if ( $post_id ) {
 			$post = get_post( $post_id, ARRAY_A );
 			return $this->prepare_item_for_response( $post, $request );

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -68,6 +68,27 @@ class Liberate_Controller_Test extends TestCase {
 		$this->assertEquals( $this->storage_post_type, $this->liberate_controller->get_storage_post_type() );
 	}
 
+	public function testValidRequestForInsert() {
+		$source_url = 'https://example.org/default'; // non-unique, already inserted in setUp()
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'sourceUrl' => $source_url,
+				)
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$result = $this->liberate_controller->valid_request_for_insert( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_source_url_not_unique', $result->get_error_code() );
+		$this->assertEquals( 409, $response->get_status() );
+	}
+
 	public function testValidRequestForUpdateRule1() {
 		// invalid id, rule 1 violation
 		$api_endpoint = $this->endpoint . '/' . PHP_INT_MAX;

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -1,6 +1,7 @@
 <?php
 
 use DotOrg\TryWordPress\Liberate_Controller;
+use DotOrg\TryWordPress\Transformer;
 use PHPUnit\Framework\TestCase;
 
 class Liberate_Controller_Test extends TestCase {
@@ -26,7 +27,7 @@ class Liberate_Controller_Test extends TestCase {
 		$this->liberate_controller = new Liberate_Controller( $this->storage_post_type );
 
 		// we instantiate Promoter class so that the sample post we insert also has its transformed post saved in the database
-		new \DotOrg\TryWordPress\Transformer( $this->storage_post_type );
+		new Transformer( $this->storage_post_type );
 
 		$this->inserted_post_id = wp_insert_post(
 			array(

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -257,4 +257,79 @@ class Liberate_Controller_Test extends TestCase {
 		$this->assertEquals( $this->parsed_date, $prepared_post['post_date'] );
 		$this->assertEquals( $this->raw_date, $prepared_post['meta']['raw_date'] );
 	}
+
+	public function testGetPostIdByGuidWithExistingPost() {
+		$guid = 'https://example.org/default'; // This GUID was set in setUp()
+
+		$post_id = $this->liberate_controller->get_post_id_by_guid( $guid );
+		$this->assertEquals( $this->inserted_post_id, $post_id );
+
+		// Test that it's cached
+		$cache_key = 'try_wp_cache_guid_' . md5( $guid );
+		$cached_id = wp_cache_get( $cache_key, 'try_wp' );
+		$this->assertEquals( $post_id, $cached_id );
+	}
+
+	public function testGetPostIdByGuidWithNonExistentPost() {
+		$guid = 'https://example.org/' . __CLASS__ . '/' . __FUNCTION__;
+
+		$post_id = $this->liberate_controller->get_post_id_by_guid( $guid );
+		$this->assertNull( $post_id );
+
+		// Verify no cache was set
+		$cache_key = 'try_wp_cache_guid_' . md5( $guid );
+		$cached_id = wp_cache_get( $cache_key, 'try_wp' );
+		$this->assertFalse( $cached_id );
+	}
+
+	public function testCacheIsInvalidatedWhenPostIsDeleted() {
+		$guid = 'https://example.org/' . __CLASS__ . '/' . __FUNCTION__;
+
+		// Create a new post
+		$new_post_id = wp_insert_post(
+			array(
+				'post_author'           => 23,
+				'post_date'             => $this->parsed_date,
+				'post_date_gmt'         => $this->parsed_date,
+				'post_content'          => $this->parsed_content,
+				'post_title'            => $this->parsed_title,
+				'post_excerpt'          => 'This is the test excerpt',
+				'post_status'           => 'draft',
+				'comment_status'        => 'closed',
+				'ping_status'           => 'closed',
+				'post_password'         => '',
+				'post_name'             => '',
+				'to_ping'               => '',
+				'pinged'                => $this->parsed_date,
+				'post_modified'         => $this->parsed_date,
+				'post_modified_gmt'     => $this->parsed_date,
+				'post_content_filtered' => $this->raw_content,
+				'post_parent'           => 0,
+				'guid'                  => $guid,
+				'menu_order'            => 0,
+				'post_type'             => $this->storage_post_type,
+				'comment_count'         => 0,
+			)
+		);
+
+		// First access to cache the post ID
+		$post_id = $this->liberate_controller->get_post_id_by_guid( $guid );
+		$this->assertEquals( $new_post_id, $post_id );
+
+		// Verify it's in cache
+		$cache_key = 'try_wp_cache_guid_' . md5( $guid );
+		$cached_id = wp_cache_get( $cache_key, 'try_wp' );
+		$this->assertEquals( $post_id, $cached_id );
+
+		// Delete the post - this should trigger our delete_post hook
+		wp_delete_post( $new_post_id, true );
+
+		// Verify cache was cleared by the hook
+		$cached_id = wp_cache_get( $cache_key, 'try_wp' );
+		$this->assertFalse( $cached_id );
+
+		// Later lookups should return null
+		$post_id = $this->liberate_controller->get_post_id_by_guid( $guid );
+		$this->assertNull( $post_id );
+	}
 }


### PR DESCRIPTION
In this PR, we mainly enforce a unique constraint on `sourceUrl`.

Additionally, we move the guid -> postId caching to Liberate_Controller and use that function in evaluating unique constraint check.

Lastly, has some tiny fixes here & there.

fixes #102 