### PR TITLE
Store HTML of source page

### DIFF
--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -110,6 +110,15 @@ class Blogpost_Controller extends Liberate_Controller {
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
+				'sourceHtml'    => array(
+					'description' => __( 'Source HTML from where the blogpost was liberated', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
 				'rawTitle'      => array(
 					'description' => __( 'Raw title of the blogpost', 'try_wordpress' ),
 					'type'        => 'string',

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -105,11 +105,12 @@ class Liberate_Controller extends WP_REST_Controller {
 			'id'            => $item['ID'],
 			'authorId'      => $item['post_author'] ?? '',
 			'sourceUrl'     => $item['guid'] ?? '',
+			'sourceHtml'    => $item['post_content_filtered'] ?? '',
 			'rawTitle'      => get_post_meta( $item['ID'], 'raw_title', true ),
 			'parsedTitle'   => $item['post_title'] ?? '',
 			'rawDate'       => get_post_meta( $item['ID'], 'raw_date', true ),
 			'parsedDate'    => $item['post_date'] ?? '',
-			'rawContent'    => $item['post_content_filtered'] ?? '',
+			'rawContent'    => get_post_meta( $item['ID'], 'raw_content', true ),
 			'parsedContent' => $item['post_content'] ?? '',
 			'transformedId' => get_post_meta( $item['ID'], '_dl_transformed', true ),
 		);
@@ -145,13 +146,14 @@ class Liberate_Controller extends WP_REST_Controller {
 		$prepared_post['post_date']             = $post_date ?? '';
 		$prepared_post['post_date_gmt']         = $post_date_gmt ?? '';
 		$prepared_post['post_content']          = $request_data['parsedContent'] ?? '';
-		$prepared_post['post_content_filtered'] = $request_data['rawContent'] ?? '';
+		$prepared_post['post_content_filtered'] = $request_data['sourceHtml'] ?? '';
 		$prepared_post['guid']                  = $request_data['sourceUrl'] ?? '';
 		$prepared_post['post_author']           = $request_data['authorId'] ?? '';
 
 		$prepared_post['meta'] = array(
-			'raw_title' => $request_data['rawTitle'] ?? '',
-			'raw_date'  => $request_data['rawDate'] ?? '',
+			'raw_title'   => $request_data['rawTitle'] ?? '',
+			'raw_date'    => $request_data['rawDate'] ?? '',
+			'raw_content' => $request_data['rawContent'] ?? '',
 		);
 
 		return $prepared_post;

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -110,6 +110,15 @@ class Page_Controller extends Liberate_Controller {
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
+				'sourceHtml'    => array(
+					'description' => __( 'Source HTML from where the page was liberated', 'try_wordpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
 				'rawTitle'      => array(
 					'description' => __( 'Raw title of the page', 'try_wordpress' ),
 					'type'        => 'string',

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -10,6 +10,7 @@ class Blogpost_Controller_Test extends TestCase {
 	private string $subject_type_plural = 'blog-posts';
 	private string $endpoint;
 	private string $storage_post_type = 'lib_1';
+	private string $source_html;
 
 	private string $raw_title       = '<h1>This is the test title</h1>';
 	private string $parsed_title    = 'This is the test title';
@@ -22,7 +23,8 @@ class Blogpost_Controller_Test extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->endpoint = '/' . $this->namespace . '/' . $this->subject_type_plural;
+		$this->endpoint    = '/' . $this->namespace . '/' . $this->subject_type_plural;
+		$this->source_html = '<html><head><title></title></head><body>' . $this->raw_content . '</body></html>';
 
 		$this->blogpost_controller = new Blogpost_Controller( $this->storage_post_type );
 	}
@@ -105,6 +107,7 @@ class Blogpost_Controller_Test extends TestCase {
 			wp_json_encode(
 				array(
 					'sourceUrl'     => $source_url,
+					'sourceHtml'    => $this->source_html,
 					'rawTitle'      => $this->raw_title,
 					'parsedTitle'   => $this->parsed_title,
 					'rawContent'    => $this->raw_content,
@@ -129,6 +132,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $this->raw_date, $response_data['rawDate'] );
 		$this->assertEquals( $this->parsed_date, $response_data['parsedDate'] );
 		$this->assertEquals( $source_url, $response_data['sourceUrl'] );
+		$this->assertEquals( $this->source_html, $response_data['sourceHtml'] );
 
 		$this->assertNotEmpty( $response_data['transformedId'] );
 

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -9,6 +9,7 @@ class Liberate_Controller_Test extends TestCase {
 
 	private string $storage_post_type = 'lib_2';
 	private string $endpoint          = '/try-wp/v1/blog-posts';
+	private string $source_html;
 
 	private string $raw_title       = '<h1>This is the test title</h1>';
 	private string $parsed_title    = 'This is the test title';
@@ -25,6 +26,8 @@ class Liberate_Controller_Test extends TestCase {
 		parent::setUp();
 
 		$this->liberate_controller = new Liberate_Controller( $this->storage_post_type );
+
+		$this->source_html = '<html><head><title></title></head><body>' . $this->raw_content . '</body></html>';
 
 		// we instantiate Promoter class so that the sample post we insert also has its transformed post saved in the database
 		new Transformer( $this->storage_post_type );
@@ -56,6 +59,7 @@ class Liberate_Controller_Test extends TestCase {
 		);
 		update_post_meta( $this->inserted_post_id, 'raw_date', $this->raw_date );
 		update_post_meta( $this->inserted_post_id, 'raw_title', $this->raw_title );
+		update_post_meta( $this->inserted_post_id, 'raw_content', $this->raw_content );
 
 		$this->transformed_post_id = get_post_meta( $this->inserted_post_id, '_dl_transformed', true );
 	}
@@ -175,7 +179,7 @@ class Liberate_Controller_Test extends TestCase {
 			'pinged'                => $this->parsed_date,
 			'post_modified'         => $this->parsed_date,
 			'post_modified_gmt'     => $this->parsed_date,
-			'post_content_filtered' => $this->raw_content,
+			'post_content_filtered' => $this->source_html,
 			'post_parent'           => 0,
 			'guid'                  => $source_url,
 			'menu_order'            => 0,
@@ -193,6 +197,7 @@ class Liberate_Controller_Test extends TestCase {
 				'id'            => $this->inserted_post_id,
 				'authorId'      => 23,
 				'sourceUrl'     => $source_url,
+				'sourceHtml'    => $this->source_html,
 				'rawTitle'      => $this->raw_title,
 				'parsedTitle'   => $this->parsed_title,
 				'rawDate'       => $this->raw_date,
@@ -217,6 +222,7 @@ class Liberate_Controller_Test extends TestCase {
 					'id'            => 777,
 					'authorId'      => 23,
 					'sourceUrl'     => $source_url,
+					'sourceHtml'    => $this->source_html,
 					'rawTitle'      => $this->raw_title,
 					'parsedTitle'   => $this->parsed_title,
 					'rawDate'       => $this->raw_date,
@@ -251,11 +257,12 @@ class Liberate_Controller_Test extends TestCase {
 			$prepared_post['post_content']
 		);
 		$this->assertEquals(
-			$this->raw_content,
+			$this->source_html,
 			$prepared_post['post_content_filtered']
 		);
 		$this->assertEquals( $this->parsed_date, $prepared_post['post_date'] );
 		$this->assertEquals( $this->raw_date, $prepared_post['meta']['raw_date'] );
+		$this->assertEquals( $this->raw_content, $prepared_post['meta']['raw_content'] );
 	}
 
 	public function testGetPostIdByGuidWithExistingPost() {

--- a/tests/plugin/test-page-controller.php
+++ b/tests/plugin/test-page-controller.php
@@ -10,6 +10,7 @@ class Page_Controller_Test extends TestCase {
 	private string $subject_type_plural = 'pages';
 	private string $endpoint;
 	private string $storage_post_type = 'lib_3';
+	private string $source_html;
 
 	private string $raw_title       = '<h1>This is the test title</h1>';
 	private string $parsed_title    = 'This is the test title';
@@ -22,7 +23,8 @@ class Page_Controller_Test extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->endpoint = '/' . $this->namespace . '/' . $this->subject_type_plural;
+		$this->endpoint    = '/' . $this->namespace . '/' . $this->subject_type_plural;
+		$this->source_html = '<html><head><title></title></head><body>' . $this->raw_content . '</body></html>';
 
 		$this->page_controller = new Page_Controller( $this->storage_post_type );
 	}
@@ -105,6 +107,7 @@ class Page_Controller_Test extends TestCase {
 			wp_json_encode(
 				array(
 					'sourceUrl'     => $source_url,
+					'sourceHtml'    => $this->source_html,
 					'rawTitle'      => $this->raw_title,
 					'parsedTitle'   => $this->parsed_title,
 					'rawContent'    => $this->raw_content,
@@ -129,6 +132,7 @@ class Page_Controller_Test extends TestCase {
 		$this->assertEquals( $this->raw_date, $response_data['rawDate'] );
 		$this->assertEquals( $this->parsed_date, $response_data['parsedDate'] );
 		$this->assertEquals( $source_url, $response_data['sourceUrl'] );
+		$this->assertEquals( $this->source_html, $response_data['sourceHtml'] );
 
 		$this->assertNotEmpty( $response_data['transformedId'] );
 


### PR DESCRIPTION
Now, I have introduced `sourceHtml` field to save page's entire html source in `post_content_filtered` column, previously which was storing `raw_content` of whatever subject_type we were working with but now that's moved to meta.

It's not a required argument as far as validation goes. Also we are currently not enforcing any update rules upon it as well. So technically, it's possible to not provide it or later overwrite it with an empty string. Don't think such a safeguard is needed, but let me know if you think we should.

closes #64 