### PR TITLE
delete post instead of trashing them

### DIFF
--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -252,8 +252,8 @@ class Blogpost_Controller extends Liberate_Controller {
 			);
 		}
 
-		if ( wp_trash_post( $request['id'] ) ) {
-			return new WP_REST_Response( true, 200 );
+		if ( wp_delete_post( $request['id'], true ) ) {
+			return new WP_REST_Response( true, 204 );
 		}
 
 		return new WP_Error( 'rest_could_not_delete', __( 'Could not delete', 'try_wordpress' ), array( 'status' => 500 ) );

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -252,8 +252,8 @@ class Page_Controller extends Liberate_Controller {
 			);
 		}
 
-		if ( wp_trash_post( $request['id'] ) ) {
-			return new WP_REST_Response( true, 200 );
+		if ( wp_delete_post( $request['id'], true ) ) {
+			return new WP_REST_Response( true, 204 );
 		}
 
 		return new WP_Error( 'rest_could_not_delete', __( 'Could not delete', 'try_wordpress' ), array( 'status' => 500 ) );

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -236,12 +236,7 @@ class Blogpost_Controller_Test extends TestCase {
 		$request         = new WP_REST_Request( 'DELETE', $delete_endpoint );
 		$response        = rest_do_request( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( $response->get_data() );
-
-		// Verify post is in trash
-		$post = get_post( $post_id );
-		$this->assertEquals( 'trash', $post->post_status );
+		$this->assertEquals( 204, $response->get_status() );
 	}
 
 	public function testDeleteNonexistentItem() {

--- a/tests/plugin/test-page-controller.php
+++ b/tests/plugin/test-page-controller.php
@@ -237,12 +237,7 @@ class Page_Controller_Test extends TestCase {
 		$request         = new WP_REST_Request( 'DELETE', $delete_endpoint );
 		$response        = rest_do_request( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( $response->get_data() );
-
-		// Verify post is in trash
-		$post = get_post( $post_id );
-		$this->assertEquals( 'trash', $post->post_status );
+		$this->assertEquals( 204, $response->get_status() );
 	}
 
 	public function testDeleteNonexistentItem() {


### PR DESCRIPTION
I opted to be conservative earlier, but now thinking about it, it makes little sense to trash it, since the usage is purely API based.

Additionally, guid -> postId cache is currently only being busted on delete hook, so this ensures desired behaviour.