### PR TITLE
Import pages through navigation (part 2)

### DIFF
--- a/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
@@ -1,11 +1,7 @@
-import { ReactElement, useEffect, useState } from 'react';
-import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
-import { Field } from '@/model/field/Field';
+import { Field, FieldType } from '@/model/field/Field';
 import { BlogPost } from '@/model/subject/BlogPost';
 import { BlogPostBlueprint } from '@/model/blueprint/BlogPost';
-import { CommandTypes, sendCommandToContent } from '@/bus/Command';
-import { EventTypes } from '@/bus/Event';
-import { ContentEventHandler } from '@/ui/blueprints/ContentEventHandler';
+import { FieldsEditor } from '@/ui/components/FieldsEditor/FieldsEditor';
 
 interface Props {
 	blueprint: BlogPostBlueprint;
@@ -15,9 +11,6 @@ interface Props {
 
 export function BlogPostBlueprintEditor( props: Props ) {
 	const { blueprint, subject, onFieldChanged } = props;
-	const [ fieldWaitingForSelection, setFieldWaitingForSelection ] = useState<
-		false | { field: Field; name: string }
-	>( false );
 
 	const subjectFields: { name: string; field: Field }[] = [
 		{ name: 'title', field: subject.title },
@@ -25,78 +18,33 @@ export function BlogPostBlueprintEditor( props: Props ) {
 		{ name: 'content', field: subject.content },
 	];
 
-	// Enable or disable highlighting according to whether a field is waiting for selection.
-	useEffect( () => {
-		const type =
-			fieldWaitingForSelection === false
-				? CommandTypes.SwitchToDefaultMode
-				: CommandTypes.SwitchToGenericSelectionMode;
-		void sendCommandToContent( { type, payload: {} } );
-	}, [ fieldWaitingForSelection ] );
-
-	const elements: ReactElement[] = [];
-	for ( const { name, field } of subjectFields ) {
-		const isWaitingForSelection =
-			!! fieldWaitingForSelection &&
-			fieldWaitingForSelection.name === name;
-
-		const blueprintField =
-			blueprint.fields[ name as keyof typeof blueprint.fields ];
-		if ( ! blueprintField ) {
-			throw new Error( `blueprint field ${ name } not found` );
-		}
-
-		elements.push(
-			<SingleFieldEditor
-				key={ name }
-				label={ name }
-				blueprintField={ blueprintField }
-				field={ field }
-				waitingForSelection={ isWaitingForSelection }
-				onWaitingForSelection={ async ( f: Field | false ) => {
-					if ( f === false ) {
-						setFieldWaitingForSelection( false );
-					} else {
-						setFieldWaitingForSelection( { field: f, name } );
-					}
-				} }
-				onClear={ async () => {
-					field.rawValue = '';
-					field.parsedValue = '';
-					onFieldChanged( name, field, '' );
-				} }
-			/>
-		);
-	}
+	const blueprintFields: {
+		name: string;
+		type: FieldType;
+		selector?: string;
+	}[] = [
+		{
+			name: 'title',
+			type: blueprint.fields.title.type,
+			selector: blueprint.fields.title.selector,
+		},
+		{
+			name: 'date',
+			type: blueprint.fields.date.type,
+			selector: blueprint.fields.date.selector,
+		},
+		{
+			name: 'content',
+			type: blueprint.fields.content.type,
+			selector: blueprint.fields.content.selector,
+		},
+	];
 
 	return (
-		<>
-			{ /*
-			Handle a click on an element in the content script,
-			according to which field is currently waiting for selection.
-			*/ }
-			<ContentEventHandler
-				eventType={ EventTypes.OnElementClick }
-				onEvent={ async ( event ) => {
-					if ( fieldWaitingForSelection === false ) {
-						console.warn(
-							'Received an OnElementClick event but no field is waiting for selection'
-						);
-						return;
-					}
-					const selector = ' ';
-					fieldWaitingForSelection.field.rawValue = (
-						event.event.payload as any
-					 ).content;
-					onFieldChanged(
-						fieldWaitingForSelection.name,
-						fieldWaitingForSelection.field,
-						selector
-					);
-					setFieldWaitingForSelection( false );
-				} }
-			/>
-			{ elements }
-		</>
+		<FieldsEditor
+			fields={ subjectFields }
+			blueprintFields={ blueprintFields }
+			onFieldChanged={ onFieldChanged }
+		/>
 	);
 }

--- a/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useEffect, useState } from 'react';
-import { FieldEditor } from '@/ui/blueprints/FieldEditor';
+import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
 import { Field } from '@/model/field/Field';
 import { BlogPost } from '@/model/subject/BlogPost';
 import { BlogPostBlueprint } from '@/model/blueprint/BlogPost';
@@ -47,7 +47,7 @@ export function BlogPostBlueprintEditor( props: Props ) {
 		}
 
 		elements.push(
-			<FieldEditor
+			<SingleFieldEditor
 				key={ name }
 				label={ name }
 				blueprintField={ blueprintField }

--- a/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/BlogPostBlueprintEditor.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldType } from '@/model/field/Field';
+import { Field } from '@/model/field/Field';
 import { BlogPost } from '@/model/subject/BlogPost';
 import { BlogPostBlueprint } from '@/model/blueprint/BlogPost';
 import { FieldsEditor } from '@/ui/components/FieldsEditor/FieldsEditor';
@@ -18,24 +18,20 @@ export function BlogPostBlueprintEditor( props: Props ) {
 		{ name: 'content', field: subject.content },
 	];
 
-	const blueprintFields: {
+	const selectors: {
 		name: string;
-		type: FieldType;
 		selector?: string;
 	}[] = [
 		{
 			name: 'title',
-			type: blueprint.fields.title.type,
 			selector: blueprint.fields.title.selector,
 		},
 		{
 			name: 'date',
-			type: blueprint.fields.date.type,
 			selector: blueprint.fields.date.selector,
 		},
 		{
 			name: 'content',
-			type: blueprint.fields.content.type,
 			selector: blueprint.fields.content.selector,
 		},
 	];
@@ -43,7 +39,7 @@ export function BlogPostBlueprintEditor( props: Props ) {
 	return (
 		<FieldsEditor
 			fields={ subjectFields }
-			blueprintFields={ blueprintFields }
+			selectors={ selectors }
 			onFieldChanged={ onFieldChanged }
 		/>
 	);

--- a/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldType } from '@/model/field/Field';
+import { Field } from '@/model/field/Field';
 import { FieldsEditor } from '@/ui/components/FieldsEditor/FieldsEditor';
 import { PageBlueprint } from '@/model/blueprint/Page';
 import { Page } from '@/model/subject/Page';
@@ -17,19 +17,16 @@ export function PageBlueprintEditor( props: Props ) {
 		{ name: 'content', field: subject.content },
 	];
 
-	const blueprintFields: {
+	const selectors: {
 		name: string;
-		type: FieldType;
 		selector?: string;
 	}[] = [
 		{
 			name: 'title',
-			type: blueprint.fields.title.type,
 			selector: blueprint.fields.title.selector,
 		},
 		{
 			name: 'content',
-			type: blueprint.fields.content.type,
 			selector: blueprint.fields.content.selector,
 		},
 	];
@@ -37,7 +34,7 @@ export function PageBlueprintEditor( props: Props ) {
 	return (
 		<FieldsEditor
 			fields={ subjectFields }
-			blueprintFields={ blueprintFields }
+			selectors={ selectors }
 			onFieldChanged={ onFieldChanged }
 		/>
 	);

--- a/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useEffect, useState } from 'react';
-import { FieldEditor } from '@/ui/blueprints/FieldEditor';
+import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
 import { Field } from '@/model/field/Field';
 import { Page } from '@/model/subject/Page';
 import { PageBlueprint } from '@/model/blueprint/Page';
@@ -47,7 +47,7 @@ export function PageBlueprintEditor( props: Props ) {
 		}
 
 		elements.push(
-			<FieldEditor
+			<SingleFieldEditor
 				key={ name }
 				label={ name }
 				blueprintField={ blueprintField }

--- a/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
+++ b/src/ui/blueprints/blog-post/PageBlueprintEditor.tsx
@@ -1,11 +1,7 @@
-import { ReactElement, useEffect, useState } from 'react';
-import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
-import { Field } from '@/model/field/Field';
-import { Page } from '@/model/subject/Page';
+import { Field, FieldType } from '@/model/field/Field';
+import { FieldsEditor } from '@/ui/components/FieldsEditor/FieldsEditor';
 import { PageBlueprint } from '@/model/blueprint/Page';
-import { CommandTypes, sendCommandToContent } from '@/bus/Command';
-import { EventTypes } from '@/bus/Event';
-import { ContentEventHandler } from '@/ui/blueprints/ContentEventHandler';
+import { Page } from '@/model/subject/Page';
 
 interface Props {
 	blueprint: PageBlueprint;
@@ -15,88 +11,34 @@ interface Props {
 
 export function PageBlueprintEditor( props: Props ) {
 	const { blueprint, subject, onFieldChanged } = props;
-	const [ fieldWaitingForSelection, setFieldWaitingForSelection ] = useState<
-		false | { field: Field; name: string }
-	>( false );
 
 	const subjectFields: { name: string; field: Field }[] = [
 		{ name: 'title', field: subject.title },
-		{ name: 'date', field: subject.date },
 		{ name: 'content', field: subject.content },
 	];
 
-	// Enable or disable highlighting according to whether a field is waiting for selection.
-	useEffect( () => {
-		const type =
-			fieldWaitingForSelection === false
-				? CommandTypes.SwitchToDefaultMode
-				: CommandTypes.SwitchToGenericSelectionMode;
-		void sendCommandToContent( { type, payload: {} } );
-	}, [ fieldWaitingForSelection ] );
-
-	const elements: ReactElement[] = [];
-	for ( const { name, field } of subjectFields ) {
-		const isWaitingForSelection =
-			!! fieldWaitingForSelection &&
-			fieldWaitingForSelection.name === name;
-
-		const blueprintField =
-			blueprint.fields[ name as keyof typeof blueprint.fields ];
-		if ( ! blueprintField ) {
-			throw new Error( `blueprint field ${ name } not found` );
-		}
-
-		elements.push(
-			<SingleFieldEditor
-				key={ name }
-				label={ name }
-				blueprintField={ blueprintField }
-				field={ field }
-				waitingForSelection={ isWaitingForSelection }
-				onWaitingForSelection={ async ( f: Field | false ) => {
-					if ( f === false ) {
-						setFieldWaitingForSelection( false );
-					} else {
-						setFieldWaitingForSelection( { field: f, name } );
-					}
-				} }
-				onClear={ async () => {
-					field.rawValue = '';
-					field.parsedValue = '';
-					onFieldChanged( name, field, '' );
-				} }
-			/>
-		);
-	}
+	const blueprintFields: {
+		name: string;
+		type: FieldType;
+		selector?: string;
+	}[] = [
+		{
+			name: 'title',
+			type: blueprint.fields.title.type,
+			selector: blueprint.fields.title.selector,
+		},
+		{
+			name: 'content',
+			type: blueprint.fields.content.type,
+			selector: blueprint.fields.content.selector,
+		},
+	];
 
 	return (
-		<>
-			{ /*
-			Handle a click on an element in the content script,
-			according to which field is currently waiting for selection.
-			*/ }
-			<ContentEventHandler
-				eventType={ EventTypes.OnElementClick }
-				onEvent={ async ( event ) => {
-					if ( fieldWaitingForSelection === false ) {
-						console.warn(
-							'Received an OnElementClick event but no field is waiting for selection'
-						);
-						return;
-					}
-					const selector = ' ';
-					fieldWaitingForSelection.field.rawValue = (
-						event.event.payload as any
-					 ).content;
-					onFieldChanged(
-						fieldWaitingForSelection.name,
-						fieldWaitingForSelection.field,
-						selector
-					);
-					setFieldWaitingForSelection( false );
-				} }
-			/>
-			{ elements }
-		</>
+		<FieldsEditor
+			fields={ subjectFields }
+			blueprintFields={ blueprintFields }
+			onFieldChanged={ onFieldChanged }
+		/>
 	);
 }

--- a/src/ui/components/FieldsEditor/FieldsEditor.tsx
+++ b/src/ui/components/FieldsEditor/FieldsEditor.tsx
@@ -1,0 +1,109 @@
+import { Field, FieldType } from '@/model/field/Field';
+import { ReactElement, useEffect, useMemo, useState } from 'react';
+import { CommandTypes, sendCommandToContent } from '@/bus/Command';
+import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
+import { ContentEventHandler } from '@/ui/blueprints/ContentEventHandler';
+import { EventTypes } from '@/bus/Event';
+
+type BlueprintFieldsMap = Map< string, { type: FieldType; selector?: string } >;
+
+// Displays a list of fields that can be "edited" by selecting the content of each field,
+// which is done by clicking on elements in the source site.
+export function FieldsEditor( props: {
+	fields: { name: string; field: Field }[];
+	blueprintFields: {
+		name: string;
+		type: FieldType;
+		selector?: string;
+	}[];
+	onFieldChanged: ( name: string, field: Field, selector: string ) => void;
+} ) {
+	const { fields, onFieldChanged } = props;
+	const [ fieldWaitingForSelection, setFieldWaitingForSelection ] = useState<
+		false | { field: Field; name: string }
+	>( false );
+
+	// Transform the blueprint fields into a map queryable by field name.
+	const blueprintFields = useMemo< BlueprintFieldsMap >( () => {
+		const map = new Map< string, { type: FieldType; selector?: string } >();
+		props.blueprintFields.forEach( ( f ) => {
+			map.set( f.name, { type: f.type, selector: f.selector } );
+		} );
+		return map;
+	}, [ props.blueprintFields ] );
+
+	// Enable or disable highlighting according to whether a field is waiting for selection.
+	useEffect( () => {
+		const type =
+			fieldWaitingForSelection === false
+				? CommandTypes.SwitchToDefaultMode
+				: CommandTypes.SwitchToGenericSelectionMode;
+		void sendCommandToContent( { type, payload: {} } );
+	}, [ fieldWaitingForSelection ] );
+
+	// Render each field.
+	const elements: ReactElement[] = [];
+	for ( const { name, field } of fields ) {
+		const isWaitingForSelection =
+			!! fieldWaitingForSelection &&
+			fieldWaitingForSelection.name === name;
+
+		const blueprintField = blueprintFields.get( name );
+		if ( ! blueprintField ) {
+			throw new Error( `blueprint field ${ name } not found` );
+		}
+
+		elements.push(
+			<SingleFieldEditor
+				key={ name }
+				label={ name }
+				blueprintField={ blueprintField }
+				field={ field }
+				waitingForSelection={ isWaitingForSelection }
+				onWaitingForSelection={ async ( f: Field | false ) => {
+					if ( f === false ) {
+						setFieldWaitingForSelection( false );
+					} else {
+						setFieldWaitingForSelection( { field: f, name } );
+					}
+				} }
+				onClear={ async () => {
+					field.rawValue = '';
+					field.parsedValue = '';
+					onFieldChanged( name, field, '' );
+				} }
+			/>
+		);
+	}
+
+	return (
+		<>
+			{ /*
+			Handle a click on an element in the content script,
+			according to which field is currently waiting for selection.
+			*/ }
+			<ContentEventHandler
+				eventType={ EventTypes.OnElementClick }
+				onEvent={ async ( event ) => {
+					if ( fieldWaitingForSelection === false ) {
+						console.warn(
+							'Received an OnElementClick event but no field is waiting for selection'
+						);
+						return;
+					}
+					const selector = ' ';
+					fieldWaitingForSelection.field.rawValue = (
+						event.event.payload as any
+					 ).content;
+					onFieldChanged(
+						fieldWaitingForSelection.name,
+						fieldWaitingForSelection.field,
+						selector
+					);
+					setFieldWaitingForSelection( false );
+				} }
+			/>
+			{ elements }
+		</>
+	);
+}

--- a/src/ui/components/FieldsEditor/FieldsEditor.tsx
+++ b/src/ui/components/FieldsEditor/FieldsEditor.tsx
@@ -1,19 +1,16 @@
-import { Field, FieldType } from '@/model/field/Field';
+import { Field } from '@/model/field/Field';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { CommandTypes, sendCommandToContent } from '@/bus/Command';
 import { SingleFieldEditor } from '@/ui/components/FieldsEditor/SingleFieldEditor';
 import { ContentEventHandler } from '@/ui/blueprints/ContentEventHandler';
 import { EventTypes } from '@/bus/Event';
 
-type BlueprintFieldsMap = Map< string, { type: FieldType; selector?: string } >;
-
 // Displays a list of fields that can be "edited" by selecting the content of each field,
 // which is done by clicking on elements in the source site.
 export function FieldsEditor( props: {
 	fields: { name: string; field: Field }[];
-	blueprintFields: {
+	selectors: {
 		name: string;
-		type: FieldType;
 		selector?: string;
 	}[];
 	onFieldChanged: ( name: string, field: Field, selector: string ) => void;
@@ -24,13 +21,15 @@ export function FieldsEditor( props: {
 	>( false );
 
 	// Transform the blueprint fields into a map queryable by field name.
-	const blueprintFields = useMemo< BlueprintFieldsMap >( () => {
-		const map = new Map< string, { type: FieldType; selector?: string } >();
-		props.blueprintFields.forEach( ( f ) => {
-			map.set( f.name, { type: f.type, selector: f.selector } );
+	const blueprintFields = useMemo<
+		Map< string, string | undefined >
+	>( () => {
+		const map = new Map< string, string >();
+		props.selectors.forEach( ( f ) => {
+			map.set( f.name, f.selector ?? '' );
 		} );
 		return map;
-	}, [ props.blueprintFields ] );
+	}, [ props.selectors ] );
 
 	// Enable or disable highlighting according to whether a field is waiting for selection.
 	useEffect( () => {
@@ -48,17 +47,17 @@ export function FieldsEditor( props: {
 			!! fieldWaitingForSelection &&
 			fieldWaitingForSelection.name === name;
 
-		const blueprintField = blueprintFields.get( name );
-		if ( ! blueprintField ) {
-			throw new Error( `blueprint field ${ name } not found` );
+		const selector = blueprintFields.get( name );
+		if ( selector === undefined ) {
+			throw new Error( `selector for field ${ name } not found` );
 		}
 
 		elements.push(
 			<SingleFieldEditor
 				key={ name }
-				label={ name }
-				blueprintField={ blueprintField }
 				field={ field }
+				label={ name }
+				selector={ selector }
 				waitingForSelection={ isWaitingForSelection }
 				onWaitingForSelection={ async ( f: Field | false ) => {
 					if ( f === false ) {

--- a/src/ui/components/FieldsEditor/SingleFieldEditor.tsx
+++ b/src/ui/components/FieldsEditor/SingleFieldEditor.tsx
@@ -1,7 +1,7 @@
 import { BlueprintField } from '@/model/blueprint/Blueprint';
 import { Field } from '@/model/field/Field';
 
-export function FieldEditor( props: {
+export function SingleFieldEditor( props: {
 	field: Field;
 	blueprintField: BlueprintField;
 	label: string;

--- a/src/ui/components/FieldsEditor/SingleFieldEditor.tsx
+++ b/src/ui/components/FieldsEditor/SingleFieldEditor.tsx
@@ -1,18 +1,17 @@
-import { BlueprintField } from '@/model/blueprint/Blueprint';
 import { Field } from '@/model/field/Field';
 
 export function SingleFieldEditor( props: {
 	field: Field;
-	blueprintField: BlueprintField;
 	label: string;
+	selector?: string;
 	waitingForSelection: boolean;
 	onWaitingForSelection: ( field: Field | false ) => void;
 	onClear: () => void;
 } ) {
 	const {
-		blueprintField,
 		field,
 		label,
+		selector,
 		waitingForSelection,
 		onWaitingForSelection,
 		onClear,
@@ -51,7 +50,7 @@ export function SingleFieldEditor( props: {
 					</button>
 					):
 				</p>
-				{ blueprintField.selector }
+				{ selector }
 			</div>
 			<div>
 				Original:


### PR DESCRIPTION
Follow-up to #103 

This is just a refactor that extracts a `FieldsEditor` component, so that the page importing can use it too. This removes some of the duplication that has recently been discussed.

The next PR will implement the page importing.