### PR TITLE
Enable OPFS only when building for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
 	"type": "module",
 	"scripts": {
-		"build": "echo 'Please choose a target: build:firefox or build:chrome, or build:production'",
-		"build:production": "rm -rf build/production && webpack --env mode=production",
+		"build": "echo 'Please choose a target: build:firefox or build:chrome, or build:production:firefox or build:production:chrome'",
+		"build:production": "echo 'Please choose a target: build:production:firefox or build:production:chrome'",
+		"build:production:firefox": "rm -rf build/production/firefox && webpack --env mode=production --env target=firefox",
+		"build:production:chrome": "rm -rf build/production/chrome && webpack --env mode=production --env target=chrome",
 		"build:firefox": "rm -rf build/firefox && webpack --env target=firefox",
 		"build:chrome": "rm -rf build/chrome && webpack --env target=chrome",
+		"preview:production": "echo 'Please choose a target: preview:production:firefox or preview:production:chrome'",
+		"preview:production:firefox": "npm run build:production:firefox && web-ext -s build/production/firefox run --target firefox-desktop",
+		"preview:production:chrome": "npm run build:production:chrome && web-ext -s build/production/chrome run --target chromium --arg='--disable-search-engine-choice-screen'",
 		"watch": "echo 'Please choose a target: watch:firefox or watch:chrome'",
 		"watch:firefox": "webpack --watch --env target=firefox",
 		"watch:chrome": "webpack --watch --env target=chrome",

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -55,7 +55,7 @@ async function initPlayground(
 	slug: string,
 	blogName: string
 ): Promise< PlaygroundClient > {
-	const opfsEnabled = true;
+	const opfsEnabled = process.env.OPFS_ENABLED === 'true';
 
 	// TODO: We should pass the initialSyncDirection property.
 	// @ts-ignore

--- a/src/ui/preview/Playground.tsx
+++ b/src/ui/preview/Playground.tsx
@@ -68,7 +68,12 @@ async function initPlayground(
 	};
 
 	const isWPInstalled = await isWordPressInstalled( slug );
-	console.info( 'isWordPressInstalled', isWPInstalled );
+	console.info(
+		'opfsEnabled:',
+		opfsEnabled,
+		'isWordPressInstalled:',
+		isWPInstalled
+	);
 
 	const options: StartPlaygroundOptions = {
 		iframe,

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -7,11 +7,19 @@ const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
+	const mode = env.mode || 'development';
+
+	// Validate environment
+	if ( mode === 'production' && ! env.target ) {
+		throw new Error(
+			'Production builds require a target. Use --env target=firefox or --env target=chrome'
+		);
+	}
+
+	// Set target(s)
 	if ( env.target ) {
 		targets = [ env.target ];
 	}
-
-	const mode = env.mode || 'development';
 
 	let modules = [];
 	for ( const target of targets ) {
@@ -60,6 +68,12 @@ function extensionModules( mode, target ) {
 		browser: 'webextension-polyfill',
 	} );
 
+	const envPlugin = new webpack.DefinePlugin( {
+		'process.env.OPFS_ENABLED': JSON.stringify(
+			mode === 'production' ? 'true' : 'false'
+		),
+	} );
+
 	return [
 		// Extension background script.
 		{
@@ -86,6 +100,7 @@ function extensionModules( mode, target ) {
 					],
 				} ),
 				webExtensionPolyfillPlugin,
+				envPlugin,
 			],
 		},
 		// Extension content script.
@@ -99,7 +114,7 @@ function extensionModules( mode, target ) {
 				path: targetPath,
 				filename: path.join( 'content.js' ),
 			},
-			plugins: [ webExtensionPolyfillPlugin ],
+			plugins: [ webExtensionPolyfillPlugin, envPlugin ],
 		},
 		// The app.
 		{
@@ -150,6 +165,7 @@ function extensionModules( mode, target ) {
 					},
 				} ),
 				webExtensionPolyfillPlugin,
+				envPlugin,
 			].concat(
 				mode === 'production' ? [ new MiniCssExtractPlugin() ] : []
 			),


### PR DESCRIPTION
For dev purposes, OPFS was being slow, so with this PR, we disable it in development and only enable it when building for production.

For this, npm scripts specifically for building for production and previewing that build have been added.

I have added its value to our existing console.info call since it might be helpful in realizing its value when something breaks. Once we switch to auto behavior for `shouldInstallWordPress`, we can consider removing it.