### PR TITLE
add testdox param to phpunit calls for detailed output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
 		],
 		"dev:db": "wp-env run cli wp db export - > backup.sql",
 		"dev:db:backup": "wp-env run cli wp db export - > backup-$(date +%Y%m%d-%H%M%S).sql",
-		"dev:test": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit",
-		"dev:test:api": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --filter 'Controller_Test'",
-		"dev:test:failing": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --group failing"
+		"dev:test": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --testdox",
+		"dev:test:api": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --testdox --filter 'Controller_Test'",
+		"dev:test:failing": "wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --testdox --group failing"
 	},
 	"config": {
 		"vendor-dir": "src/plugin/vendor",


### PR DESCRIPTION
Makes for nice detailed output:

```
$ composer run dev:test
> wp-env run tests-cli --env-cwd=wp-content/ plugins/plugin/vendor/bin/phpunit --testdox
ℹ Starting 'plugins/plugin/vendor/bin/phpunit --testdox' on the tests-cli container.

Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

Blogpost_Controller_
 ✔ Register routes
 ✔ Schema endpoint
 ✔ Create item empty body
 ✔ Create item minimal body
 ✔ Create item full body
 ✔ Create item missing source url
 ✔ Update item
 ✔ Delete item
 ✔ Delete nonexistent item
 ✔ Find by source url no args
 ✔ Find by source url no url
 ✔ Find by source url valid url
 ✔ Find by source url invalid url
 ✔ Guid cache

Liberate_Controller_
 ✔ Get storage post type
 ✔ Valid request for insert
 ✔ Valid request for update rule 1
 ✔ Valid request for update rule 2
 ✔ Valid request for update success
 ✔ Prepare item for response without id
 ✔ Prepare item for response
 ✔ Prepare item for database
 ✔ Get post id by guid with existing post
 ✔ Get post id by guid with non existent post
 ✔ Cache is invalidated when post is deleted

Page_Controller_
 ✔ Register routes
 ✔ Schema endpoint
 ✔ Create item empty body
 ✔ Create item minimal body
 ✔ Create item full body
 ✔ Create item missing source url
 ✔ Update item
 ✔ Delete item
 ✔ Delete nonexistent item
 ✔ Find by source url no args
 ✔ Find by source url no url
 ✔ Find by source url valid url
 ✔ Find by source url invalid url
 ✔ Guid cache

Storage_
 ✔ Register post types

Transformer_
 ✔ Get post type for transformed post
 ✔ Get transformed post
 ✔ Transform

Time: 00:00.340, Memory: 42.50 MB

OK (43 tests, 121 assertions)
✔ Ran `plugins/plugin/vendor/bin/phpunit --testdox` in 'tests-cli'. (in 1s 876ms)
```