### PR TITLE
Documentation for integrating and extending

### DIFF
--- a/EXTEND.md
+++ b/EXTEND.md
@@ -27,11 +27,11 @@ We maintain references between the source data and transformed output using two 
 This two-way reference allows both Try WordPress and your plugin to track relationships between original content and
 transformed posts.
 
-But using our hooks and filters is a better way to integrate, and that's what we recommend. See below.
+However, we recommend integrating using our hooks and filters. See below:
 
 ## Integration Points
 
-One option is to have your plugin be available during data liberation and handle transformations while showing realtime
+One option is to have your plugin be available during data liberation and handle transformations while showing real-time
 previews to the user. This is referred to as "Integration During Liberation" below.
 
 Another option is to have your plugin be aware of liberated data and process liberated data once your plugin is
@@ -42,8 +42,8 @@ not attempt to process data at activation as some sites can be quite large.
 
 #### 1. Transform Data Your Way
 
-Use the `data_liberated_{$subject_type}` action hook to implement your own transformation logic. This hook fires after
-content is liberated from source website, giving you access to the raw data through the Subject class.
+Use the `data_liberated_{$subject_type}` action hook to implement your transformation logic. This hook fires after
+content is liberated from the source website, giving you access to the raw data through the Subject class.
 
 The [Subject class](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/class-subject.php) provides a
 clean API to access raw data and existing transformed output:
@@ -68,10 +68,10 @@ add_action( 'data_liberated_product', function( $subject ) {
         'post_status' => 'publish',
     ) );
     
-    // Store reference to the source
+    // Store a reference to the source
     update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
     
-    // Store reference to your transformation in the source
+    // Store a reference to your transformation in the source
     $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
     $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
     update_post_meta( $subject->id(), $meta_key, $my_product_id );
@@ -123,10 +123,10 @@ foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
         'post_status' => 'publish',
     ) );
     
-    // Store reference to the source
+    // Store a reference to the source
     update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
     
-    // Store reference to your transformation in the source
+    // Store a reference to your transformation in the source
     $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
     $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
     update_post_meta( $subject->id(), $meta_key, $my_product_id );

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -3,8 +3,8 @@
 ## Definitions
 
 Each identified piece of content is referred to as
-a [subject](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/class-subject.php), and hence has
-a [subject type](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/subject-type.php).
+a [subject](src/plugin/class-subject.php), and hence has
+a [subject type](src/plugin/subject-type.php).
 
 The act of extracting data is referred to as `liberation` and the act of using the extracted raw data to convert into a
 usable form is referred to as "transformation" throughout the documentation and code.
@@ -45,7 +45,7 @@ not attempt to process data at activation as some sites can be quite large.
 Use the `data_liberated_{$subject_type}` action hook to implement your transformation logic. This hook fires after
 content is liberated from the source website, giving you access to the raw data through the Subject class.
 
-The [Subject class](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/class-subject.php) provides a
+The [Subject class](src/plugin/class-subject.php) provides a
 clean API to access raw data and existing transformed output:
 
 `// @TODO provide api to access transformed output`

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -57,11 +57,11 @@ add_action( 'data_liberated_product', function( $subject ) {
     $date    = $subject->date;
     $content = $subject->content;
     
-    // access entire html source of page
+    // access the entire HTML source of page
     // $subject->source_html
     
-    // access transformation output
-    // $subject->transformed_post();
+    // access native transformation output
+    // $subject->get_transformed_post();
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(
@@ -72,13 +72,11 @@ add_action( 'data_liberated_product', function( $subject ) {
         'post_status'  => 'publish',
     ) );
     
-    // Store a reference to the source
-    update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
+    // Store reference, with a unique slug representing your plugin
+    $subject->store_reference( $my_product_id, 'mycompany_myplugin_unique_slug' );
     
-    // Store a reference to your transformation in the source
-    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
-    update_post_meta( $subject->id(), $meta_key, $my_product_id );
+    // access your plugin's transformation output
+    // $subject->get_transformed_post( 'mycompany_myplugin_unique_slug' );
 } );
 ```
 
@@ -100,10 +98,9 @@ add_filter( 'data_liberation_preview_transformed_post_id', function( $default_po
     }
     
     // Find your transformed product
-    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
-    $product_id = get_post_meta( $subject->id(), $meta_key, true );
-    return $product_id ? $product_id : $default_post_id;
+    $post = $subject->get_transformed_post( 'mycompany_myplugin_unique_slug' );
+    
+    return $post ? $post->ID : $default_post_id;
 }, 10, 2 );
 ```
 
@@ -118,11 +115,11 @@ foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
     $date    = $subject->date;
     $content = $subject->content;
     
-    // access entire html source of page
+    // access the entire HTML source of page
     // $subject->source_html
     
-    // access transformation output
-    // $subject->transformed_post();
+    // access native transformation output
+    // $subject->get_transformed_post();
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(
@@ -133,13 +130,11 @@ foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
         'post_status'  => 'publish',
     ) );
     
-    // Store a reference to the source
-    update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
+    // Store reference, with a unique slug representing your plugin
+    $subject->store_reference( $my_product_id, 'mycompany_myplugin_unique_slug' );
     
-    // Store a reference to your transformation in the source
-    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
-    update_post_meta( $subject->id(), $meta_key, $my_product_id );
+    // access your plugin's transformation output
+    // $subject->get_transformed_post( 'mycompany_myplugin_unique_slug' );
 }
 ```
 

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -55,17 +55,17 @@ For example, to transform product data into your custom product post type:
 ```php
 add_action( 'data_liberated_product', function( $subject ) {
     // process raw data
-    $title = $subject->title;
-    $date = $subject->date;
+    $title   = $subject->title;
+    $date    = $subject->date;
     $content = $subject->content;
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(
-        'post_type' => 'my_product_type',
-        'post_title' => $title,
-        'post_date' => $date,
+        'post_type'    => 'my_product_type',
+        'post_title'   => $title,
+        'post_date'    => $date,
         'post_content' => $content,
-        'post_status' => 'publish',
+        'post_status'  => 'publish',
     ) );
     
     // Store a reference to the source
@@ -110,17 +110,17 @@ add_filter( 'data_liberation_preview_transformed_post_id', function( $default_po
 ```php
 foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
     // process raw data
-    $title = $subject->title;
-    $date = $subject->date;
+    $title   = $subject->title;
+    $date    = $subject->date;
     $content = $subject->content;
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(
-        'post_type' => 'my_product_type',
-        'post_title' => $title,
-        'post_date' => $date,
+        'post_type'    => 'my_product_type',
+        'post_title'   => $title,
+        'post_date'    => $date,
         'post_content' => $content,
-        'post_status' => 'publish',
+        'post_status'  => 'publish',
     ) );
     
     // Store a reference to the source

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -48,8 +48,6 @@ content is liberated from the source website, giving you access to the raw data 
 The [Subject class](src/plugin/class-subject.php) provides a
 clean API to access raw data and existing transformed output:
 
-`// @TODO provide api to access transformed output`
-
 For example, to transform product data into your custom product post type:
 
 ```php
@@ -58,6 +56,12 @@ add_action( 'data_liberated_product', function( $subject ) {
     $title   = $subject->title;
     $date    = $subject->date;
     $content = $subject->content;
+    
+    // access entire html source of page
+    // $subject->source_html
+    
+    // access transformation output
+    // $subject->transformed_post();
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(
@@ -113,6 +117,12 @@ foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
     $title   = $subject->title;
     $date    = $subject->date;
     $content = $subject->content;
+    
+    // access entire html source of page
+    // $subject->source_html
+    
+    // access transformation output
+    // $subject->transformed_post();
     
     // Create a product in your custom post type
     $my_product_id = wp_insert_post( array(

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -4,7 +4,7 @@
 
 Each identified piece of content is referred to as
 a [subject](src/plugin/class-subject.php), and hence has
-a [subject type](src/plugin/subject-type.php).
+a [subject type](src/plugin/enum-subject-type.php).
 
 The act of extracting data is referred to as `liberation` and the act of using the extracted raw data to convert into a
 usable form is referred to as "transformation" throughout the documentation and code.

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -1,0 +1,151 @@
+# Receive Liberated Data
+
+## Definitions
+
+Each identified piece of content is referred to as
+a [subject](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/class-subject.php), and hence has
+a [subject type](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/subject-type.php).
+
+The act of extracting data is referred to as `liberation` and the act of using the extracted raw data to convert into a
+usable form is referred to as "transformation" throughout the documentation and code.
+
+While liberating data, we always store the raw data that we are handling in hopes of running a better transformation in
+the future or any third-party plugin to transform the data upon installation of their plugin.
+
+## Storage Architecture
+
+Try WordPress stores all liberated data in a custom post type called `liberated_data`, exposed via a constant:
+`\DotOrg\TryWordPress\Engine::STORAGE_POST_TYPE`.
+
+We maintain references between the source data and transformed output using two post meta keys:
+
+- `_data_liberation_source`: Points to the source content (exposed via
+  `\DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE`)
+- `_data_liberation_output`: Points to the transformed output (exposed via
+  `\DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT`)
+
+This two-way reference allows both Try WordPress and your plugin to track relationships between original content and
+transformed posts.
+
+But using our hooks and filters is a better way to integrate, and that's what we recommend. See below.
+
+## Integration Points
+
+One option is to have your plugin be available during data liberation and handle transformations while showing realtime
+previews to the user. This is referred to as "Integration During Liberation" below.
+
+Another option is to have your plugin be aware of liberated data and process liberated data once your plugin is
+installed, preferably by walking the user through a UI. This is referred to as "Integration Post Liberation". Please do
+not attempt to process data at activation as some sites can be quite large.
+
+### Integration During Liberation
+
+#### 1. Transform Data Your Way
+
+Use the `data_liberated_{$subject_type}` action hook to implement your own transformation logic. This hook fires after
+content is liberated from source website, giving you access to the raw data through the Subject class.
+
+The [Subject class](https://github.com/WordPress/try-wordpress/blob/docs/extend/src/plugin/class-subject.php) provides a
+clean API to access raw data and existing transformed output:
+
+`// @TODO provide api to access transformed output`
+
+For example, to transform product data into your custom product post type:
+
+```php
+add_action( 'data_liberated_product', function( $subject ) {
+    // process raw data
+    $title = $subject->title;
+    $date = $subject->date;
+    $content = $subject->content;
+    
+    // Create a product in your custom post type
+    $my_product_id = wp_insert_post( array(
+        'post_type' => 'my_product_type',
+        'post_title' => $title,
+        'post_date' => $date,
+        'post_content' => $content,
+        'post_status' => 'publish',
+    ) );
+    
+    // Store reference to the source
+    update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
+    
+    // Store reference to your transformation in the source
+    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    update_post_meta( $subject->id(), $meta_key, $my_product_id );
+} );
+```
+
+#### 2. Control the Preview
+
+Use the `transformed_post_id` filter to tell us which post to show in the preview. This filter receives:
+
+- The default transformed post ID
+- The Subject instance
+
+Here's how to show your transformed product:
+
+```php
+add_filter( 'transformed_post_id', function( $default_post_id, $subject ) {
+    // Only handle product transformations
+    if ( $subject->type !== 'product' ) {
+        return $default_post_id;
+    }
+    
+    // Find your transformed product
+    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    $product_id = get_post_meta( $subject->id(), $meta_key, true );
+    return $product_id ? $product_id : $default_post_id;
+}, 10, 2 );
+```
+
+### Integration Post Liberation
+
+#### Transform Data Your Way
+
+```php
+foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
+    // process raw data
+    $title = $subject->title;
+    $date = $subject->date;
+    $content = $subject->content;
+    
+    // Create a product in your custom post type
+    $my_product_id = wp_insert_post( array(
+        'post_type' => 'my_product_type',
+        'post_title' => $title,
+        'post_date' => $date,
+        'post_content' => $content,
+        'post_status' => 'publish',
+    ) );
+    
+    // Store reference to the source
+    update_post_meta( $my_product_id, \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_SOURCE, $subject->id() );
+    
+    // Store reference to your transformation in the source
+    $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    update_post_meta( $subject->id(), $meta_key, $my_product_id );
+}
+```
+
+## Best Practices
+
+1. Always use the Subject class's public API to access liberated data. Don't rely on internal implementation details.
+2. Store references between your transformed content and the liberated data. This helps with future updates or
+   re-transformations.
+3. Handle errors gracefully in your transformations. Return the default post ID from your filter if anything goes wrong.
+4. Document your transformations. Help users understand what your plugin does with their liberated content.
+
+## Need Help?
+
+Open an issue on our [GitHub repository](https://github.com/WordPress/try-wordpress) if you:
+
+- Need additional integration points
+- Have a use case not covered by current hooks
+- Want to discuss your integration approach
+
+We actively work with plugin authors to ensure Try WordPress meets real-world needs.

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -73,7 +73,7 @@ add_action( 'data_liberated_product', function( $subject ) {
     
     // Store reference to your transformation in the source
     $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
     update_post_meta( $subject->id(), $meta_key, $my_product_id );
 } );
 ```
@@ -97,7 +97,7 @@ add_filter( 'data_liberation_preview_transformed_post_id', function( $default_po
     
     // Find your transformed product
     $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
     $product_id = get_post_meta( $subject->id(), $meta_key, true );
     return $product_id ? $product_id : $default_post_id;
 }, 10, 2 );
@@ -128,7 +128,7 @@ foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
     
     // Store reference to your transformation in the source
     $unique_plugin_slug = 'mycompany_myplugin_my_product_type'; // make sure this is unique for your plugin
-    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+    $meta_key = \DotOrg\TryWordPress\Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug; // definitely use this prefix
     update_post_meta( $subject->id(), $meta_key, $my_product_id );
 }
 ```

--- a/EXTEND.md
+++ b/EXTEND.md
@@ -80,7 +80,8 @@ add_action( 'data_liberated_product', function( $subject ) {
 
 #### 2. Control the Preview
 
-Use the `transformed_post_id` filter to tell us which post to show in the preview. This filter receives:
+Use the `data_liberation_preview_transformed_post_id` filter to tell us which post to show in the preview. This filter
+receives:
 
 - The default transformed post ID
 - The Subject instance
@@ -88,7 +89,7 @@ Use the `transformed_post_id` filter to tell us which post to show in the previe
 Here's how to show your transformed product:
 
 ```php
-add_filter( 'transformed_post_id', function( $default_post_id, $subject ) {
+add_filter( 'data_liberation_preview_transformed_post_id', function( $default_post_id, $subject ) {
     // Only handle product transformations
     if ( $subject->type !== 'product' ) {
         return $default_post_id;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Try WordPress
+
 _Try WordPress_ allows you to **import your existing website to WordPress** in an intuitive way.
 
 It's a browser extension that comes with a local WordPress site, and makes it easy for you to import content from your existing site. At the end, you can export the local site to its permanent location, at a WordPress host of your choosing.
@@ -11,8 +12,10 @@ It's a browser extension that comes with a local WordPress site, and makes it ea
 Currently, the extension is not published to the browser extension stores, so you will not be able to install it directly from your browser. Instead, the easiest way to install the extension is by following the [development environment setup instructions](CONTRIBUTING.md).
 
 ## How to contribute
+
 There are multiple ways you can contribute to this project:
 
 - Submit improvements or fixes to the Try WordPress browser extension itself: see [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Create or improve site definitions so that other users can more easily import their site: Coming soon.
-- Create or improve transformation plugins so that content can better fit in the WordPress plugin ecosystem: Coming soon.
+- Create or improve transformation plugins so that content can better fit in the WordPress plugin ecosystem: see [
+  `EXTEND.md`](EXTEND.md)

--- a/src/plugin/class-blogpost-controller.php
+++ b/src/plugin/class-blogpost-controller.php
@@ -222,7 +222,14 @@ class Blogpost_Controller extends Liberate_Controller {
 		foreach ( $item_meta as $key => $value ) {
 			update_post_meta( $item['ID'], $key, $value );
 		}
-		update_post_meta( $item['ID'], 'subject_type', 'blog-post' );
+		update_post_meta( $item['ID'], 'subject_type', SubjectType::BLOGPOST->value );
+
+		// data_liberated_blogpost hook
+		do_action(
+			'data_liberated_' . SubjectType::BLOGPOST->value,
+			Subject::from_post( $item['ID'] ),
+			'create'
+		);
 
 		return $this->prepare_item_for_response( $item, $request );
 	}
@@ -245,6 +252,13 @@ class Blogpost_Controller extends Liberate_Controller {
 		foreach ( $item_meta as $key => $value ) {
 			update_post_meta( $item['ID'], $key, $value );
 		}
+
+		// data_liberated_blogpost hook
+		do_action(
+			'data_liberated_' . SubjectType::BLOGPOST->value,
+			Subject::from_post( $item['ID'] ),
+			'update'
+		);
 
 		return $this->prepare_item_for_response( $item, $request );
 	}

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -16,6 +16,7 @@ class Engine {
 		require 'class-page-controller.php';
 		require 'class-storage.php';
 		require 'class-subject.php';
+		require 'class-subject-repo.php';
 
 		( function () {
 			$transformer = new Transformer();
@@ -27,6 +28,8 @@ class Engine {
 			new Page_Controller( self::STORAGE_POST_TYPE );
 
 			new Storage( self::STORAGE_POST_TYPE );
+
+			Subject_Repo::init( self::STORAGE_POST_TYPE );
 		} )();
 	}
 }

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -4,7 +4,7 @@ namespace DotOrg\TryWordPress;
 
 class Engine {
 
-	private string $storage_post_type = 'liberated_data';
+	public const string STORAGE_POST_TYPE = 'liberated_data';
 
 	public function __construct() {
 		require 'class-post-type-ui.php';
@@ -15,15 +15,15 @@ class Engine {
 		require 'class-storage.php';
 
 		( function () {
-			$transformer = new Transformer( $this->storage_post_type );
+			$transformer = new Transformer( self::STORAGE_POST_TYPE );
 
-			new Post_Type_UI( $this->storage_post_type, $transformer );
+			new Post_Type_UI( self::STORAGE_POST_TYPE, $transformer );
 
 			// REST API
-			new Blogpost_Controller( $this->storage_post_type );
-			new Page_Controller( $this->storage_post_type );
+			new Blogpost_Controller( self::STORAGE_POST_TYPE );
+			new Page_Controller( self::STORAGE_POST_TYPE );
 
-			new Storage( $this->storage_post_type );
+			new Storage( self::STORAGE_POST_TYPE );
 		} )();
 	}
 }

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -18,7 +18,7 @@ class Engine {
 		require 'class-subject.php';
 
 		( function () {
-			$transformer = new Transformer( self::STORAGE_POST_TYPE );
+			$transformer = new Transformer();
 
 			new Post_Type_UI( self::STORAGE_POST_TYPE, $transformer );
 

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -7,12 +7,15 @@ class Engine {
 	public const string STORAGE_POST_TYPE = 'liberated_data';
 
 	public function __construct() {
+		require 'enum-subject-type.php';
+
 		require 'class-post-type-ui.php';
 		require 'class-transformer.php';
 		require 'class-liberate-controller.php';
 		require 'class-blogpost-controller.php';
 		require 'class-page-controller.php';
 		require 'class-storage.php';
+		require 'class-subject.php';
 
 		( function () {
 			$transformer = new Transformer( self::STORAGE_POST_TYPE );

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -117,7 +117,7 @@ class Liberate_Controller extends WP_REST_Controller {
 		// allow filtration of what post should be treated as the transformed output
 		$response['transformedId'] = apply_filters(
 			'transformed_post_id',
-			get_post_meta( $item['ID'], '_dl_transformed', true ),
+			get_post_meta( $item['ID'], Transformer::META_KEY_LIBERATED_OUTPUT, true ),
 			Subject::from_post( $item['ID'] )
 		);
 

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -112,7 +112,13 @@ class Liberate_Controller extends WP_REST_Controller {
 			'parsedDate'    => $item['post_date'] ?? '',
 			'rawContent'    => get_post_meta( $item['ID'], 'raw_content', true ),
 			'parsedContent' => $item['post_content'] ?? '',
-			'transformedId' => get_post_meta( $item['ID'], '_dl_transformed', true ),
+		);
+
+		// allow filtration of what post should be treated as the transformed output
+		$response['transformedId'] = apply_filters(
+			'transformed_post_id',
+			get_post_meta( $item['ID'], '_dl_transformed', true ),
+			Subject::from_post( $item['ID'] )
 		);
 
 		$response['previewUrl'] = get_permalink( $response['transformedId'] );

--- a/src/plugin/class-liberate-controller.php
+++ b/src/plugin/class-liberate-controller.php
@@ -116,7 +116,7 @@ class Liberate_Controller extends WP_REST_Controller {
 
 		// allow filtration of what post should be treated as the transformed output
 		$response['transformedId'] = apply_filters(
-			'transformed_post_id',
+			'data_liberation_preview_transformed_post_id',
 			get_post_meta( $item['ID'], Transformer::META_KEY_LIBERATED_OUTPUT, true ),
 			Subject::from_post( $item['ID'] )
 		);

--- a/src/plugin/class-page-controller.php
+++ b/src/plugin/class-page-controller.php
@@ -222,7 +222,14 @@ class Page_Controller extends Liberate_Controller {
 		foreach ( $item_meta as $key => $value ) {
 			update_post_meta( $item['ID'], $key, $value );
 		}
-		update_post_meta( $item['ID'], 'subject_type', 'page' );
+		update_post_meta( $item['ID'], 'subject_type', SubjectType::PAGE->value );
+
+		// data_liberated_page hook
+		do_action(
+			'data_liberated_' . SubjectType::PAGE->value,
+			Subject::from_post( $item['ID'] ),
+			'create'
+		);
 
 		return $this->prepare_item_for_response( $item, $request );
 	}
@@ -245,6 +252,13 @@ class Page_Controller extends Liberate_Controller {
 		foreach ( $item_meta as $key => $value ) {
 			update_post_meta( $item['ID'], $key, $value );
 		}
+
+		// data_liberated_page hook
+		do_action(
+			'data_liberated_' . SubjectType::PAGE->value,
+			Subject::from_post( $item['ID'] ),
+			'update'
+		);
 
 		return $this->prepare_item_for_response( $item, $request );
 	}

--- a/src/plugin/class-post-type-ui.php
+++ b/src/plugin/class-post-type-ui.php
@@ -100,7 +100,7 @@ class Post_Type_UI {
 						global $post;
 
 						$post_id             = $post->ID;
-						$transformed_post_id = $this->transformer->get_transformed_post_id( $post_id );
+						$transformed_post_id = get_post_meta( $post_id, Transformer::META_KEY_LIBERATED_OUTPUT, true );
 
 						if ( $transformed_post_id ) {
 							echo '<pre>PostID: ' . esc_html( $transformed_post_id ) . '</pre>';

--- a/src/plugin/class-subject-repo.php
+++ b/src/plugin/class-subject-repo.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+class Subject_Repo {
+	private static string $post_type;
+
+	public static function init( string $post_type ): void {
+		static::$post_type = $post_type;
+	}
+
+	/**
+	 * Loops over all liberated_post posts for the specified subject_type
+	 *
+	 * @TODO: pagination support for large sites
+	 *
+	 * @param string $subject_type Type of subject.
+	 * @return Subject[]
+	 */
+	public static function loop( string $subject_type ): array {
+		$args = array(
+			'post_type'      => static::$post_type,
+			'post_status'    => 'draft',
+			'posts_per_page' => -1,
+		);
+
+		if ( ! empty( $subject_type ) ) {
+			// @phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			$args['meta_query'] = array(
+				'key'     => 'subject_type',
+				'value'   => $subject_type,
+				'compare' => '=',
+			);
+		}
+
+		return array_map(
+			function ( $post ) {
+				return Subject::from_post( $post->ID );
+			},
+			get_posts( $args )
+		);
+	}
+}

--- a/src/plugin/class-subject.php
+++ b/src/plugin/class-subject.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use WP_Post;
+
+/**
+ * Subject class offers an easy view of liberated data, abstracting away the implementation details
+ *
+ * WP specific data is private and only exposed via methods to limit leakage of implementation details
+ * Raw data is available as public fields
+ */
+class Subject {
+
+	private int $id;
+
+	public string $source_html;
+	public string $type;
+	public string $title;
+	public string $date;
+	public string $content;
+
+	/**
+	 * Creates a new Subject instance from a WordPress post.
+	 *
+	 * @param int $post_id The WordPress post ID to create the subject from.
+	 * @return Subject|false The Subject instance or false if the post doesn't exist.
+	 */
+	public static function from_post( int $post_id ): Subject|false {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
+
+		return new self( $post );
+	}
+
+	/**
+	 * Private constructor to enforce using the factory method.
+	 *
+	 * @param WP_Post $post The WordPress post to create the subject from.
+	 */
+	private function __construct( WP_Post $post ) {
+		$this->id          = $post->ID;
+		$this->source_html = $post->post_content_filtered;
+
+		$this->type    = get_post_meta( $post->ID, 'subject_type', true );
+		$this->title   = get_post_meta( $post->ID, 'raw_title', true );
+		$this->date    = get_post_meta( $post->ID, 'raw_date', true );
+		$this->content = get_post_meta( $post->ID, 'raw_content', true );
+	}
+
+	public function id(): int {
+		return $this->id;
+	}
+}

--- a/src/plugin/class-subject.php
+++ b/src/plugin/class-subject.php
@@ -13,7 +13,6 @@ use WP_Post;
 class Subject {
 
 	private int $id;
-	private int $transformed_post_id;
 
 	public string $source_html;
 	public string $type;
@@ -50,15 +49,28 @@ class Subject {
 		$this->title   = get_post_meta( $post->ID, 'raw_title', true );
 		$this->date    = get_post_meta( $post->ID, 'raw_date', true );
 		$this->content = get_post_meta( $post->ID, 'raw_content', true );
-
-		$this->transformed_post_id = absint( get_post_meta( $post->ID, Transformer::META_KEY_LIBERATED_OUTPUT, true ) );
 	}
 
 	public function id(): int {
 		return $this->id;
 	}
 
-	public function transformed_post(): WP_Post {
-		return WP_Post::get_instance( $this->transformed_post_id );
+	public function get_transformed_post( string $unique_plugin_slug ): WP_Post {
+		$meta_key = Transformer::META_KEY_LIBERATED_OUTPUT;
+		if ( ! empty( $unique_plugin_slug ) ) {
+			$meta_key .= '_' . $unique_plugin_slug;
+		}
+		$transformed_post_id = absint( get_post_meta( $this->id, $meta_key, true ) );
+
+		return WP_Post::get_instance( $transformed_post_id );
+	}
+
+	public function store_reference( int $transformed_post_id, string $unique_plugin_slug ): void {
+		// Store a reference to the source
+		update_post_meta( $transformed_post_id, Transformer::META_KEY_LIBERATED_SOURCE, $this->id );
+
+		// Store a reference to your transformation in the source
+		$meta_key = Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
+		update_post_meta( $this->id, $meta_key, $transformed_post_id );
 	}
 }

--- a/src/plugin/class-subject.php
+++ b/src/plugin/class-subject.php
@@ -13,6 +13,7 @@ use WP_Post;
 class Subject {
 
 	private int $id;
+	private int $transformed_post_id;
 
 	public string $source_html;
 	public string $type;
@@ -49,9 +50,15 @@ class Subject {
 		$this->title   = get_post_meta( $post->ID, 'raw_title', true );
 		$this->date    = get_post_meta( $post->ID, 'raw_date', true );
 		$this->content = get_post_meta( $post->ID, 'raw_content', true );
+
+		$this->transformed_post_id = absint( get_post_meta( $post->ID, Transformer::META_KEY_LIBERATED_OUTPUT, true ) );
 	}
 
 	public function id(): int {
 		return $this->id;
+	}
+
+	public function transformed_post(): WP_Post {
+		return WP_Post::get_instance( $this->transformed_post_id );
 	}
 }

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -5,6 +5,7 @@ namespace DotOrg\TryWordPress;
 use WP_Post;
 
 class Transformer {
+	public const string META_KEY_LIBERATED_SOURCE = '_data_liberation_source';
 	public const string META_KEY_LIBERATED_OUTPUT = '_data_liberation_output';
 
 	public function __construct() {
@@ -93,7 +94,9 @@ class Transformer {
 			return false;
 		}
 
+		update_post_meta( $inserted_post_id, self::META_KEY_LIBERATED_SOURCE, $liberated_post->ID );
 		update_post_meta( $liberated_post->ID, self::META_KEY_LIBERATED_OUTPUT, $inserted_post_id );
+
 		return true;
 	}
 }

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -5,7 +5,7 @@ namespace DotOrg\TryWordPress;
 use WP_Post;
 
 class Transformer {
-	private string $meta_key_for_transformed_post = '_dl_transformed';
+	public const string META_KEY_LIBERATED_OUTPUT = '_data_liberation_output';
 
 	public function __construct() {
 		foreach ( SubjectType::cases() as $case ) {
@@ -37,7 +37,7 @@ class Transformer {
 	}
 
 	public function get_transformed_post_id( $liberated_post_id ): int|null {
-		$value = get_post_meta( $liberated_post_id, $this->meta_key_for_transformed_post, true );
+		$value = get_post_meta( $liberated_post_id, self::META_KEY_LIBERATED_OUTPUT, true );
 		if ( '' === $value ) {
 			return null;
 		}
@@ -50,7 +50,7 @@ class Transformer {
 			$liberated_post = get_post( $liberated_post );
 		}
 
-		$transformed_post_id = get_post_meta( $liberated_post->ID, $this->meta_key_for_transformed_post, true );
+		$transformed_post_id = get_post_meta( $liberated_post->ID, self::META_KEY_LIBERATED_OUTPUT, true );
 
 		$title = $liberated_post->post_title;
 		if ( empty( $title ) ) {
@@ -93,7 +93,7 @@ class Transformer {
 			return false;
 		}
 
-		add_post_meta( $liberated_post->ID, $this->meta_key_for_transformed_post, $inserted_post_id );
+		update_post_meta( $liberated_post->ID, self::META_KEY_LIBERATED_OUTPUT, $inserted_post_id );
 		return true;
 	}
 }

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -19,13 +19,9 @@ class Transformer {
 		}
 	}
 
-	private function get_post_type_for_transformed_post( int|WP_Post $liberated_post ): string {
-		if ( is_int( $liberated_post ) ) {
-			$liberated_post = get_post( $liberated_post );
-		}
-
+	private function get_post_type_for_transformed_post( int $liberated_post_id ): string {
 		$subject_type = SubjectType::tryFrom(
-			get_post_meta( $liberated_post->ID, 'subject_type', true )
+			get_post_meta( $liberated_post_id, 'subject_type', true )
 		);
 
 		$post_type = match ( $subject_type ) {

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -7,15 +7,15 @@ use WP_Post;
 class Transformer {
 	private string $meta_key_for_transformed_post = '_dl_transformed';
 
-	public function __construct( $post_type ) {
-		add_action(
-			'save_post_' . $post_type,
-			function ( $post_id, $post ) {
-				$this->transform( $post );
-			},
-			10,
-			2
-		);
+	public function __construct() {
+		foreach ( SubjectType::cases() as $case ) {
+			add_action(
+				'data_liberated_' . $case->value,
+				function ( $subject ) {
+					$this->transform( $subject->id() );
+				}
+			);
+		}
 	}
 
 	private function get_post_type_for_transformed_post( int|WP_Post $liberated_post ): string {

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -46,10 +46,6 @@ class Transformer {
 	}
 
 	public function transform( int|WP_Post $liberated_post ): bool {
-		if ( apply_filters( 'skip_native_transformation', false ) ) {
-			return true;
-		}
-
 		if ( is_int( $liberated_post ) ) {
 			$liberated_post = get_post( $liberated_post );
 		}

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -33,8 +33,7 @@ class Transformer {
 			default               => 'post',
 		};
 
-		// @TODO: filter name would be changed w.r.t new verb in place of 'transformed' once its decided
-		return apply_filters( 'post_type_for_transformed_post', $post_type, $liberated_post );
+		return $post_type;
 	}
 
 	public function get_transformed_post_id( $liberated_post_id ): int|null {

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -33,15 +33,6 @@ class Transformer {
 		return $post_type;
 	}
 
-	public function get_transformed_post_id( $liberated_post_id ): int|null {
-		$value = get_post_meta( $liberated_post_id, self::META_KEY_LIBERATED_OUTPUT, true );
-		if ( '' === $value ) {
-			return null;
-		}
-
-		return absint( $value );
-	}
-
 	public function transform( int|WP_Post $liberated_post ): bool {
 		if ( is_int( $liberated_post ) ) {
 			$liberated_post = get_post( $liberated_post );

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -23,20 +23,15 @@ class Transformer {
 			$liberated_post = get_post( $liberated_post );
 		}
 
-		$subject_type = get_post_meta( $liberated_post->ID, 'subject_type', true );
-		switch ( $subject_type ) {
-			case 'blog-post':
-				$post_type = 'post';
-				break;
-			case 'product':
-				$post_type = 'product';
-				break;
-			case 'page':
-				$post_type = 'page';
-				break;
-			default:
-				$post_type = 'post';
-		}
+		$subject_type = SubjectType::tryFrom(
+			get_post_meta( $liberated_post->ID, 'subject_type', true )
+		);
+
+		$post_type = match ( $subject_type ) {
+			SubjectType::PAGE     => 'page',
+			SubjectType::PRODUCT  => 'product',
+			default               => 'post',
+		};
 
 		// @TODO: filter name would be changed w.r.t new verb in place of 'transformed' once its decided
 		return apply_filters( 'post_type_for_transformed_post', $post_type, $liberated_post );

--- a/src/plugin/enum-subject-type.php
+++ b/src/plugin/enum-subject-type.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+enum SubjectType: string {
+	case BLOGPOST = 'blog-post';
+	case PAGE     = 'page';
+	case PRODUCT  = 'product';
+
+	public function get_display_name(): string {
+		return ucfirst( $this->value );
+	}
+}

--- a/tests/plugin/test-liberate-controller.php
+++ b/tests/plugin/test-liberate-controller.php
@@ -61,7 +61,7 @@ class Liberate_Controller_Test extends TestCase {
 		update_post_meta( $this->inserted_post_id, 'raw_title', $this->raw_title );
 		update_post_meta( $this->inserted_post_id, 'raw_content', $this->raw_content );
 
-		$this->transformed_post_id = get_post_meta( $this->inserted_post_id, '_dl_transformed', true );
+		$this->transformed_post_id = get_post_meta( $this->inserted_post_id, Transformer::META_KEY_LIBERATED_OUTPUT, true );
 	}
 
 	protected function tearDown(): void {

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -26,7 +26,7 @@ class Transformer_Test extends TestCase {
 		);
 		update_post_meta( $this->post_id_in_db, 'subject_type', 'blog-post' );
 
-		$this->transformer = new Transformer( 'lib_x' );
+		$this->transformer = new Transformer();
 	}
 
 	protected function tearDown(): void {

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -34,11 +34,9 @@ class Transformer_Test extends TestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 
-		$transformed_post_id = $this->transformer->get_transformed_post_id( $this->post_id_in_db );
+		$transformed_post_id = get_post_meta( $this->post_id_in_db, Transformer::META_KEY_LIBERATED_OUTPUT, true );
 		wp_delete_post( $transformed_post_id, true );
 		wp_delete_post( $this->post_id_in_db, true );
-
-		delete_post_meta( 99, Transformer::META_KEY_LIBERATED_OUTPUT );
 	}
 
 	public function testGetPostTypeForTransformedPost() {
@@ -54,17 +52,10 @@ class Transformer_Test extends TestCase {
 		$this->assertEquals( 'product', $result );
 	}
 
-	public function testGetTransformedPost() {
-		add_post_meta( 99, Transformer::META_KEY_LIBERATED_OUTPUT, 999 );
-
-		$this->assertEquals( 999, $this->transformer->get_transformed_post_id( 99 ) );
-		$this->assertEquals( null, $this->transformer->get_transformed_post_id( 88 ) );
-	}
-
 	public function testTransform(): void {
 		$result = $this->transformer->transform( get_post( $this->post_id_in_db ) );
 
-		$transformed_post_id = absint( get_post_meta( $this->post_id_in_db, Transformer::META_KEY_LIBERATED_OUTPUT, true ) );
+		$transformed_post_id = get_post_meta( $this->post_id_in_db, Transformer::META_KEY_LIBERATED_OUTPUT, true );
 
 		$this->assertEquals( $this->post_id_in_db + 1, $transformed_post_id );
 		$this->assertTrue( $result );

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -1,6 +1,7 @@
 <?php
 
 use DotOrg\TryWordPress\Transformer;
+use DotOrg\TryWordPress\SubjectType;
 use PHPUnit\Framework\TestCase;
 
 class Transformer_Test extends TestCase {
@@ -24,7 +25,7 @@ class Transformer_Test extends TestCase {
 				'post_type'             => 'liberated_data',
 			)
 		);
-		update_post_meta( $this->post_id_in_db, 'subject_type', 'blog-post' );
+		update_post_meta( $this->post_id_in_db, 'subject_type', SubjectType::BLOGPOST->value );
 
 		$this->transformer = new Transformer();
 	}
@@ -46,7 +47,7 @@ class Transformer_Test extends TestCase {
 		$result = $method->invokeArgs( $this->transformer, array( $this->post_id_in_db ) );
 		$this->assertEquals( 'post', $result );
 
-		update_post_meta( $this->post_id_in_db, 'subject_type', 'product' );
+		update_post_meta( $this->post_id_in_db, 'subject_type', SubjectType::PRODUCT->value );
 
 		$result = $method->invokeArgs( $this->transformer, array( $this->post_id_in_db ) );
 		$this->assertEquals( 'product', $result );

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -36,7 +36,7 @@ class Transformer_Test extends TestCase {
 		wp_delete_post( $transformed_post_id, true );
 		wp_delete_post( $this->post_id_in_db, true );
 
-		delete_post_meta( 99, '_dl_transformed' );
+		delete_post_meta( 99, Transformer::META_KEY_LIBERATED_OUTPUT );
 	}
 
 	public function testGetPostTypeForTransformedPost() {
@@ -53,7 +53,7 @@ class Transformer_Test extends TestCase {
 	}
 
 	public function testGetTransformedPost() {
-		add_post_meta( 99, '_dl_transformed', 999 );
+		add_post_meta( 99, Transformer::META_KEY_LIBERATED_OUTPUT, 999 );
 
 		$this->assertEquals( 999, $this->transformer->get_transformed_post_id( 99 ) );
 		$this->assertEquals( null, $this->transformer->get_transformed_post_id( 88 ) );
@@ -62,7 +62,7 @@ class Transformer_Test extends TestCase {
 	public function testTransform(): void {
 		$result = $this->transformer->transform( get_post( $this->post_id_in_db ) );
 
-		$transformed_post_id = absint( get_post_meta( $this->post_id_in_db, '_dl_transformed', true ) );
+		$transformed_post_id = absint( get_post_meta( $this->post_id_in_db, Transformer::META_KEY_LIBERATED_OUTPUT, true ) );
 
 		$this->assertEquals( $this->post_id_in_db + 1, $transformed_post_id );
 		$this->assertTrue( $result );

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -1,5 +1,6 @@
 <?php
 
+use DotOrg\TryWordPress\Engine;
 use DotOrg\TryWordPress\Transformer;
 use DotOrg\TryWordPress\SubjectType;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,7 @@ class Transformer_Test extends TestCase {
 				'post_status'           => 'draft',
 				'post_content_filtered' => '<div><p>Content 1</p><p>Content 2</p></div>',
 				'guid'                  => 'https://example.com/x',
-				'post_type'             => 'liberated_data',
+				'post_type'             => Engine::STORAGE_POST_TYPE,
 			)
 		);
 		update_post_meta( $this->post_id_in_db, 'subject_type', SubjectType::BLOGPOST->value );


### PR DESCRIPTION
This PR provides a WordPress-y API for integrating with data liberation.

See [Rendered documentation](https://github.com/WordPress/try-wordpress/blob/docs/extend/EXTEND.md)

Apart from that, it has all the code changes required to support the behavior as per documentation along with some improvements. Can be reviewed commit by commit.

In a follow up PR, I can add tests for `Subject` and `Subject_Repo` class.