### PR TITLE
Simulate data liberation via hook

### DIFF
--- a/src/plugin/class-subject-repo.php
+++ b/src/plugin/class-subject-repo.php
@@ -7,6 +7,18 @@ class Subject_Repo {
 
 	public static function init( string $post_type ): void {
 		static::$post_type = $post_type;
+
+		add_action( 'do_data_liberation', array( __CLASS__, 'simulate_data_liberation' ) );
+	}
+
+	public static function simulate_data_liberation( $subject_type ): void {
+		foreach ( self::loop( $subject_type ) as $subject ) {
+			do_action(
+				'data_liberated_' . $subject_type,
+				$subject,
+				'simulate'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR attempts to explore the feedback provided in #125 for plugins wanting to participate in "post" liberation by not having to specify the same code twice.

**Problem:**

During liberation hook
```
add_action( 'data_liberated_product', function( $subject ) {
    // some code
} );
```

Post liberation hook
```
foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
    // same code here
}
```

Suggested solution as it was discussed on call was to: Just trigger the `data_liberated_X` hook again in post liberation handling. The plugin can indicate when it wants to do that by `do_action( 'do_data_liberation', 'product' );` and we would fire the `data_liberated_product` hook to which the plugin is already attached. This PR has the code for it, but the problem with this approach is, there could be other plugins still attached to `data_liberated_product` and we don't want all of them to be executing, only the one triggering it. In order to achieve that, we would have to hack global state, which is an anti-pattern I would like to avoid.

-----

So, how about the solution to be just this?

We ask the developers, to define a function to handle the subject type they are interested in:
```
function unique_prefix_subject_handler( $subject) {
     // all code goes here
}
```

and update docs to 

During liberation hook
```
add_action( 'data_liberated_product', 'unique_prefix_subject_handler' );
```

Post liberation hook
```
foreach( \DotOrg\TryWordPress\Subject_Repo::loop( 'product' ) as $subject ) {
    unique_prefix_subject_handler( $subject );
}
```

Pretty simple solution! Thoughts?