### PR TITLE
Control preview automatically

### DIFF
--- a/src/plugin/class-subject.php
+++ b/src/plugin/class-subject.php
@@ -72,5 +72,13 @@ class Subject {
 		// Store a reference to your transformation in the source
 		$meta_key = Transformer::META_KEY_LIBERATED_OUTPUT . '_' . $unique_plugin_slug;
 		update_post_meta( $this->id, $meta_key, $transformed_post_id );
+
+		// Control preview
+		add_filter(
+			'data_liberation_preview_transformed_post_id',
+			function () use ( $transformed_post_id ) {
+				return $transformed_post_id;
+			}
+		);
 	}
 }


### PR DESCRIPTION
This PR attempts to explore the possibility of being able to control the preview automatically without having to do it separately.

I have added the filter call within the function responsible for storing reference, so that developers just have to do a single call and everything is taken care of.

This exposes a flaw in our current approach (#125) of letting multiple plugins compete for a subject type. In reality, we want the user to evaluate multiple options to see which one they want. Eventually, only one would/should win and be the final transformed output of that subject.

Additionally, only one preview can be rendered at any time, so it doesn't make sense to have multiple plugins compete & transform at the same time.

Its like buying shoes really, you want to evaluate multiple ones to see which one you like, even try them one by one but you can't try multiple ones at the same time and eventually you only buy the best one.

This is why in my previous approach (#123) I made it a point to detect when plugins compete and only advance with just the chosen plugin with previews functional without having to do anything. So, I propose the solution of being able to resolve this by exposing a dropdown in the UI for instance.

With this PR, I hope to finalize the decision of how we should handle previews. 