### PR TITLE
Build step for merging json schema files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 vendor/
 
 .phpunit.result.cache
+src/plugin/schema.json

--- a/schema/page.json
+++ b/schema/page.json
@@ -1,0 +1,9 @@
+{
+    "page": {
+        "title": "Page",
+        "fields": {
+            "title": "String",
+            "content": "String"
+        }
+    }
+} 

--- a/schema/post.json
+++ b/schema/post.json
@@ -1,0 +1,15 @@
+{
+    "post": {
+        "title": "Blog Post",
+        "fields": {
+            "date": {
+                "type": "Date",
+                "description": "date of the post",
+                "required": true
+            },
+            "author": "String",
+            "title": "String",
+            "content": "String"
+        }
+    }
+} 

--- a/schema/product.json
+++ b/schema/product.json
@@ -1,0 +1,10 @@
+{
+    "product": {
+        "title": "Product",
+        "fields": {
+            "title": "ProductString",
+            "description": "String",
+            "price": "currency"
+        }
+    }
+} 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -154,7 +154,7 @@ function extensionModules( mode, target ) {
 						},
 					],
 				} ),
-				new EmitMergedJsonPlugin(),
+				new EmitSubjectsSchemaPlugin(),
 				// Create plugin.zip.
 				new FileManagerPlugin( {
 					events: {
@@ -181,14 +181,14 @@ function extensionModules( mode, target ) {
 }
 
 // Create a custom plugin to emit the merged JSON file
-class EmitMergedJsonPlugin {
+class EmitSubjectsSchemaPlugin {
 	apply( compiler ) {
 		compiler.hooks.compilation.tap(
-			'EmitMergedJsonPlugin',
+			'EmitSubjectsSchemaPlugin',
 			( compilation ) => {
 				compilation.hooks.processAssets.tapAsync(
 					{
-						name: 'EmitMergedJsonPlugin',
+						name: 'EmitSubjectsSchemaPlugin',
 						stage: webpack.Compilation
 							.PROCESS_ASSETS_STAGE_ADDITIONAL,
 					},

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -11,72 +11,6 @@ const SCHEMA_SRC_DIR = './schema';
 const SCHEMA_OUTPUT_NAME = 'schema.json';
 const SCHEMA_OUTPUT_PATHS = [ './dist/config', './public/config' ];
 
-// Create a custom plugin to emit the merged JSON file
-class EmitMergedJsonPlugin {
-	apply( compiler ) {
-		compiler.hooks.emit.tapAsync(
-			'EmitMergedJsonPlugin',
-			async ( compilation, callback ) => {
-				try {
-					const mergedContent = JSON.stringify(
-						await mergeJsonFiles( SCHEMA_SRC_DIR ),
-						null,
-						2
-					);
-
-					// Write to all output paths
-					await Promise.all(
-						SCHEMA_OUTPUT_PATHS.map( async ( outputPath ) => {
-							await fs.promises.mkdir( outputPath, {
-								recursive: true,
-							} );
-							await fs.promises.writeFile(
-								path.join( outputPath, SCHEMA_OUTPUT_NAME ),
-								mergedContent
-							);
-						} )
-					);
-
-					// Also emit for webpack output
-					compilation.assets[ SCHEMA_OUTPUT_NAME ] = {
-						source: () => mergedContent,
-						size: () => mergedContent.length,
-					};
-				} catch ( error ) {
-					console.error( 'Error during JSON merge:', error );
-				}
-				callback();
-			}
-		);
-	}
-}
-
-async function mergeJsonFiles( sourceDir ) {
-	const mergedData = {};
-
-	const files = ( await fs.promises.readdir( sourceDir ) ).filter( ( file ) =>
-		file.endsWith( '.json' )
-	);
-
-	await Promise.all(
-		files.map( async ( file ) => {
-			const filePath = path.join( sourceDir, file );
-			try {
-				const fileContent = await fs.promises.readFile(
-					filePath,
-					'utf8'
-				);
-				const jsonData = JSON.parse( fileContent );
-				Object.assign( mergedData, jsonData );
-			} catch ( error ) {
-				console.error( `Error parsing JSON file ${ file }:`, error );
-			}
-		} )
-	);
-
-	return mergedData;
-}
-
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
 	const mode = env.mode || 'development';
@@ -244,4 +178,70 @@ function extensionModules( mode, target ) {
 			),
 		},
 	];
+}
+
+// Create a custom plugin to emit the merged JSON file
+class EmitMergedJsonPlugin {
+	apply( compiler ) {
+		compiler.hooks.emit.tapAsync(
+			'EmitMergedJsonPlugin',
+			async ( compilation, callback ) => {
+				try {
+					const mergedContent = JSON.stringify(
+						await mergeJsonFiles( SCHEMA_SRC_DIR ),
+						null,
+						2
+					);
+
+					// Write to all output paths
+					await Promise.all(
+						SCHEMA_OUTPUT_PATHS.map( async ( outputPath ) => {
+							await fs.promises.mkdir( outputPath, {
+								recursive: true,
+							} );
+							await fs.promises.writeFile(
+								path.join( outputPath, SCHEMA_OUTPUT_NAME ),
+								mergedContent
+							);
+						} )
+					);
+
+					// Also emit for webpack output
+					compilation.assets[ SCHEMA_OUTPUT_NAME ] = {
+						source: () => mergedContent,
+						size: () => mergedContent.length,
+					};
+				} catch ( error ) {
+					console.error( 'Error during JSON merge:', error );
+				}
+				callback();
+			}
+		);
+	}
+}
+
+async function mergeJsonFiles( sourceDir ) {
+	const mergedData = {};
+
+	const files = ( await fs.promises.readdir( sourceDir ) ).filter( ( file ) =>
+		file.endsWith( '.json' )
+	);
+
+	await Promise.all(
+		files.map( async ( file ) => {
+			const filePath = path.join( sourceDir, file );
+			try {
+				const fileContent = await fs.promises.readFile(
+					filePath,
+					'utf8'
+				);
+				const jsonData = JSON.parse( fileContent );
+				Object.assign( mergedData, jsonData );
+			} catch ( error ) {
+				console.error( `Error parsing JSON file ${ file }:`, error );
+			}
+		} )
+	);
+
+	return mergedData;
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -9,7 +9,7 @@ const fs = require( 'fs' );
 // @TODO: Sample paths, need to update
 const SCHEMA_SRC_DIR = './schema';
 const SCHEMA_OUTPUT_NAME = 'schema.json';
-const WP_PLUGIN_SCHEMA_PATH = path.join( 'src/plugin', 'schema.json' );
+const WP_PLUGIN_SCHEMA_PATH = path.join( 'src/plugin', SCHEMA_OUTPUT_NAME );
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -183,38 +183,52 @@ function extensionModules( mode, target ) {
 // Create a custom plugin to emit the merged JSON file
 class EmitMergedJsonPlugin {
 	apply( compiler ) {
-		compiler.hooks.emit.tapAsync(
+		compiler.hooks.compilation.tap(
 			'EmitMergedJsonPlugin',
-			async ( compilation, callback ) => {
-				try {
-					const mergedContent = JSON.stringify(
-						await mergeJsonFiles( SCHEMA_SRC_DIR ),
-						null,
-						2
-					);
-
-					// Write to all output paths
-					await Promise.all(
-						SCHEMA_OUTPUT_PATHS.map( async ( outputPath ) => {
-							await fs.promises.mkdir( outputPath, {
-								recursive: true,
-							} );
-							await fs.promises.writeFile(
-								path.join( outputPath, SCHEMA_OUTPUT_NAME ),
-								mergedContent
+			( compilation ) => {
+				compilation.hooks.processAssets.tapAsync(
+					{
+						name: 'EmitMergedJsonPlugin',
+						stage: webpack.Compilation
+							.PROCESS_ASSETS_STAGE_ADDITIONAL,
+					},
+					async ( assets, callback ) => {
+						try {
+							const mergedContent = JSON.stringify(
+								await mergeJsonFiles( SCHEMA_SRC_DIR ),
+								null,
+								2
 							);
-						} )
-					);
 
-					// Also emit for webpack output
-					compilation.assets[ SCHEMA_OUTPUT_NAME ] = {
-						source: () => mergedContent,
-						size: () => mergedContent.length,
-					};
-				} catch ( error ) {
-					console.error( 'Error during JSON merge:', error );
-				}
-				callback();
+							// Write to all output paths
+							await Promise.all(
+								SCHEMA_OUTPUT_PATHS.map(
+									async ( outputPath ) => {
+										await fs.promises.mkdir( outputPath, {
+											recursive: true,
+										} );
+										await fs.promises.writeFile(
+											path.join(
+												outputPath,
+												SCHEMA_OUTPUT_NAME
+											),
+											mergedContent
+										);
+									}
+								)
+							);
+
+							// Also emit for webpack output
+							compilation.emitAsset( SCHEMA_OUTPUT_NAME, {
+								source: () => mergedContent,
+								size: () => mergedContent.length,
+							} );
+						} catch ( error ) {
+							console.error( 'Error during JSON merge:', error );
+						}
+						callback();
+					}
+				);
 			}
 		);
 	}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -4,6 +4,78 @@ const { TsconfigPathsPlugin } = require( 'tsconfig-paths-webpack-plugin' );
 const FileManagerPlugin = require( 'filemanager-webpack-plugin' );
 const webpack = require( 'webpack' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const fs = require( 'fs' );
+
+// @TODO: Sample paths, need to update
+const SCHEMA_SRC_DIR = './schema';
+const SCHEMA_OUTPUT_NAME = 'schema.json';
+const SCHEMA_OUTPUT_PATHS = [ './dist/config', './public/config' ];
+
+// Create a custom plugin to emit the merged JSON file
+class EmitMergedJsonPlugin {
+	apply( compiler ) {
+		compiler.hooks.emit.tapAsync(
+			'EmitMergedJsonPlugin',
+			async ( compilation, callback ) => {
+				try {
+					const mergedContent = JSON.stringify(
+						await mergeJsonFiles( SCHEMA_SRC_DIR ),
+						null,
+						2
+					);
+
+					// Write to all output paths
+					await Promise.all(
+						SCHEMA_OUTPUT_PATHS.map( async ( outputPath ) => {
+							await fs.promises.mkdir( outputPath, {
+								recursive: true,
+							} );
+							await fs.promises.writeFile(
+								path.join( outputPath, SCHEMA_OUTPUT_NAME ),
+								mergedContent
+							);
+						} )
+					);
+
+					// Also emit for webpack output
+					compilation.assets[ SCHEMA_OUTPUT_NAME ] = {
+						source: () => mergedContent,
+						size: () => mergedContent.length,
+					};
+				} catch ( error ) {
+					console.error( 'Error during JSON merge:', error );
+				}
+				callback();
+			}
+		);
+	}
+}
+
+async function mergeJsonFiles( sourceDir ) {
+	const mergedData = {};
+
+	const files = ( await fs.promises.readdir( sourceDir ) ).filter( ( file ) =>
+		file.endsWith( '.json' )
+	);
+
+	await Promise.all(
+		files.map( async ( file ) => {
+			const filePath = path.join( sourceDir, file );
+			try {
+				const fileContent = await fs.promises.readFile(
+					filePath,
+					'utf8'
+				);
+				const jsonData = JSON.parse( fileContent );
+				Object.assign( mergedData, jsonData );
+			} catch ( error ) {
+				console.error( `Error parsing JSON file ${ file }:`, error );
+			}
+		} )
+	);
+
+	return mergedData;
+}
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
@@ -101,6 +173,7 @@ function extensionModules( mode, target ) {
 				} ),
 				webExtensionPolyfillPlugin,
 				envPlugin,
+				new EmitMergedJsonPlugin(),
 			],
 		},
 		// Extension content script.

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -9,7 +9,7 @@ const fs = require( 'fs' );
 // @TODO: Sample paths, need to update
 const SCHEMA_SRC_DIR = './schema';
 const SCHEMA_OUTPUT_NAME = 'schema.json';
-const SCHEMA_OUTPUT_PATHS = [ './dist/config', './public/config' ];
+const WP_PLUGIN_SCHEMA_PATH = path.join( 'src/plugin', 'schema.json' );
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
@@ -107,7 +107,6 @@ function extensionModules( mode, target ) {
 				} ),
 				webExtensionPolyfillPlugin,
 				envPlugin,
-				new EmitMergedJsonPlugin(),
 			],
 		},
 		// Extension content script.
@@ -155,6 +154,7 @@ function extensionModules( mode, target ) {
 						},
 					],
 				} ),
+				new EmitMergedJsonPlugin(),
 				// Create plugin.zip.
 				new FileManagerPlugin( {
 					events: {
@@ -200,23 +200,9 @@ class EmitMergedJsonPlugin {
 								2
 							);
 
-							// Write to all output paths
-							await Promise.all(
-								SCHEMA_OUTPUT_PATHS.map(
-									async ( outputPath ) => {
-										await fs.promises.mkdir( outputPath, {
-											recursive: true,
-										} );
-										await fs.promises.writeFile(
-											path.join(
-												outputPath,
-												SCHEMA_OUTPUT_NAME
-											),
-											mergedContent
-										);
-									}
-								)
-							);
+							// Write to WordPress plugin directory
+							await fs.promises.mkdir(path.dirname(WP_PLUGIN_SCHEMA_PATH), { recursive: true });
+							await fs.promises.writeFile(WP_PLUGIN_SCHEMA_PATH, mergedContent);
 
 							// Also emit for webpack output
 							compilation.emitAsset( SCHEMA_OUTPUT_NAME, {

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -134,6 +134,7 @@ function extensionModules( mode, target ) {
 				filename: path.join( 'app.js' ),
 			},
 			plugins: [
+				new EmitSubjectsSchemaPlugin(),
 				new CopyPlugin( {
 					patterns: [
 						{
@@ -154,11 +155,20 @@ function extensionModules( mode, target ) {
 						},
 					],
 				} ),
-				new EmitSubjectsSchemaPlugin(),
 				// Create plugin.zip.
 				new FileManagerPlugin( {
 					events: {
 						onEnd: {
+							copy: [
+								{
+									source: WP_PLUGIN_SCHEMA_PATH,
+									destination: path.join(
+										targetPath,
+										'plugin',
+										SCHEMA_OUTPUT_NAME
+									),
+								},
+							],
 							archive: [
 								{
 									source: path.join( targetPath, 'plugin' ),

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -201,8 +201,14 @@ class EmitMergedJsonPlugin {
 							);
 
 							// Write to WordPress plugin directory
-							await fs.promises.mkdir(path.dirname(WP_PLUGIN_SCHEMA_PATH), { recursive: true });
-							await fs.promises.writeFile(WP_PLUGIN_SCHEMA_PATH, mergedContent);
+							await fs.promises.mkdir(
+								path.dirname( WP_PLUGIN_SCHEMA_PATH ),
+								{ recursive: true }
+							);
+							await fs.promises.writeFile(
+								WP_PLUGIN_SCHEMA_PATH,
+								mergedContent
+							);
 
 							// Also emit for webpack output
 							compilation.emitAsset( SCHEMA_OUTPUT_NAME, {


### PR DESCRIPTION
Added a custom webpack plugin `EmitMergedJsonPlugin` that:
  - Reads all JSON files from a specified source directory
  - Merges them into a single JSON object
  - Outputs the merged schema to multiple locations:
    - Build directory
    - WordPress plugin src dir

Next, we need to figure out the output paths, but that can happen in the PR which starts using the generated schema file.

closes #144

------
Output sample:
```
cat build/firefox/schema.json
{
  "page": {
    "title": "Page",
    "fields": {
      "title": "String",
      "content": "String"
    }
  },
  "post": {
    "title": "Blog Post",
    "fields": {
      "date": {
        "type": "Date",
        "description": "date of the post",
        "required": true
      },
      "author": "String",
      "title": "String",
      "content": "String"
    }
  },
  "product": {
    "title": "Product",
    "fields": {
      "title": "ProductString",
      "description": "String",
      "price": "currency"
    }
  }
}
```