### PR TITLE
Infinite builds loop fix

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -141,10 +141,6 @@ function extensionModules( mode, target ) {
 							from: './src/ui/app.html',
 							to: path.join( targetPath, 'app.html' ),
 						},
-					],
-				} ),
-				new CopyPlugin( {
-					patterns: [
 						{
 							from: '**/*',
 							context: 'src/plugin/',

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -10,6 +10,7 @@ const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
 const SCHEMA_SRC = './schema/schema.json';
 const SCHEMA_OUTPUT_NAME = 'schema.json';
+const SCHEMA_SRC_PATH = path.resolve( __dirname, SCHEMA_SRC );
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
@@ -70,6 +71,10 @@ function extensionModules( mode, target ) {
 		],
 	};
 
+	const watchOptions = {
+		ignored: [ SCHEMA_SRC_PATH ],
+	};
+
 	const webExtensionPolyfillPlugin = new webpack.ProvidePlugin( {
 		browser: 'webextension-polyfill',
 	} );
@@ -108,6 +113,7 @@ function extensionModules( mode, target ) {
 				webExtensionPolyfillPlugin,
 				envPlugin,
 			],
+			watchOptions,
 		},
 		// Extension content script.
 		{
@@ -121,6 +127,7 @@ function extensionModules( mode, target ) {
 				filename: path.join( 'content.js' ),
 			},
 			plugins: [ webExtensionPolyfillPlugin, envPlugin ],
+			watchOptions,
 		},
 		// The app.
 		{
@@ -180,6 +187,7 @@ function extensionModules( mode, target ) {
 			].concat(
 				mode === 'production' ? [ new MiniCssExtractPlugin() ] : []
 			),
+			watchOptions,
 		},
 	];
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -10,7 +10,6 @@ const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
 const SCHEMA_SRC = './schema/schema.json';
 const SCHEMA_OUTPUT_NAME = 'schema.json';
-const WP_PLUGIN_SCHEMA_PATH = path.join( 'src/plugin', SCHEMA_OUTPUT_NAME );
 
 module.exports = function ( env ) {
 	let targets = [ 'firefox', 'chrome' ];
@@ -160,16 +159,6 @@ function extensionModules( mode, target ) {
 				new FileManagerPlugin( {
 					events: {
 						onEnd: {
-							copy: [
-								{
-									source: WP_PLUGIN_SCHEMA_PATH,
-									destination: path.join(
-										targetPath,
-										'plugin',
-										SCHEMA_OUTPUT_NAME
-									),
-								},
-							],
 							archive: [
 								{
 									source: path.join( targetPath, 'plugin' ),
@@ -205,16 +194,6 @@ class EmitSubjectsSchemaPlugin {
 					async ( assets, callback ) => {
 						execSync( './schema/build.mjs', { stdio: 'inherit' } );
 						const schema = readFileSync( SCHEMA_SRC );
-
-						// Write to WordPress plugin directory
-						await fs.promises.mkdir(
-							path.dirname( WP_PLUGIN_SCHEMA_PATH ),
-							{ recursive: true }
-						);
-						await fs.promises.writeFile(
-							WP_PLUGIN_SCHEMA_PATH,
-							schema
-						);
 
 						// Also emit for webpack output
 						compilation.emitAsset( SCHEMA_OUTPUT_NAME, {

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -157,11 +157,11 @@ function extensionModules( mode, target ) {
 							to: path.join( targetPath, 'plugin' ),
 						},
 						{
-							from: './schema/schema.json',
+							from: SCHEMA_SRC,
 							to: path.join(
 								targetPath,
 								'plugin',
-								'schema.json'
+								SCHEMA_OUTPUT_NAME
 							),
 						},
 					],

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -149,6 +149,14 @@ function extensionModules( mode, target ) {
 							},
 							to: path.join( targetPath, 'plugin' ),
 						},
+						{
+							from: './schema/schema.json',
+							to: path.join(
+								targetPath,
+								'plugin',
+								'schema.json'
+							),
+						},
 					],
 				} ),
 				// Create plugin.zip.

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,4 +1,3 @@
-const fs = require( 'fs' );
 const { readFileSync } = require( 'node:fs' );
 const path = require( 'node:path' );
 const { execSync } = require( 'child_process' );


### PR DESCRIPTION
In this PR, we decided to not drop a generated file into `src` dir for WP so as to avoid the situation of generated file re-triggering a build.

`schema.json` is now only generated under `schema` dir and copied to the right places under the build dir. And is now also configured to be ignored by webpack's watching for changes. 

This resolves the infinite loop of building assets.