### PR TITLE
Schema transformation to drive API endpoints

### DIFF
--- a/.github/workflows/wp-tests.yml
+++ b/.github/workflows/wp-tests.yml
@@ -1,57 +1,63 @@
 name: Tests (WP plugin)
 
 on:
-  pull_request:
-    types: [ opened, synchronize ]
+    pull_request:
+        types: [ opened, synchronize ]
 
 jobs:
-  phpunit:
-    name: PHPUnit ${{ matrix.php }}
-    runs-on: ubuntu-latest
+    phpunit:
+        name: PHPUnit ${{ matrix.php }}
+        runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:5.7
-        ports:
-          - 3306/tcp
-        env:
-          MYSQL_ROOT_PASSWORD: password
-        # Set health checks to wait until mysql has started
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
+        services:
+            mysql:
+                image: mysql:5.7
+                ports:
+                    - 3306/tcp
+                env:
+                    MYSQL_ROOT_PASSWORD: password
+                # Set health checks to wait until mysql has started
+                options: >-
+                    --health-cmd "mysqladmin ping"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 3
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '8.3' ]
+        strategy:
+            fail-fast: false
+            matrix:
+                php: [ '8.3' ]
 
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
+        steps:
+            -   name: Check out Git repository
+                uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: 'none'
-          tools: composer
+            -   name: Setup npm
+                uses: actions/setup-node@v4
 
-      - name: Install dependencies
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: "--no-progress --no-ansi --no-interaction"
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: 'none'
+                    tools: composer
 
-      - name: Install WordPress test setup
-        run: bash tests/bin/install-wp-tests.sh wordpress_test root password 127.0.0.1:${{ job.services.mysql.ports[3306] }} latest
+            -   name: Install dependencies
+                uses: ramsey/composer-install@v2
+                with:
+                    composer-options: "--no-progress --no-ansi --no-interaction"
 
-      - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+            -   name: Build schema.json
+                run: npm install && npm run build:schema && cp schema/schema.json src/plugin/
 
-      - name: Run tests
-        env:
-          WP_TESTS_DIR: /tmp/wordpress-tests-lib/
-          PHPUNIT_UNDER_GITHUB_ACTIONS: true
-        run: src/plugin/vendor/bin/phpunit
+            -   name: Install WordPress test setup
+                run: bash tests/bin/install-wp-tests.sh wordpress_test root password 127.0.0.1:${{ job.services.mysql.ports[3306] }} latest
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run tests
+                env:
+                    WP_TESTS_DIR: /tmp/wordpress-tests-lib/
+                    PHPUNIT_UNDER_GITHUB_ACTIONS: true
+                run: src/plugin/vendor/bin/phpunit

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -11,6 +11,7 @@ class Engine {
 		require 'class-transformer.php';
 		require 'class-subjects-controller.php';
 		require 'class-storage.php';
+		require 'class-schema.php';
 
 		( function () {
 			$transformer = new Transformer( $this->storage_post_type );

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -12,6 +12,7 @@ class Engine {
 		require 'class-subjects-controller.php';
 		require 'class-storage.php';
 		require 'class-schema.php';
+		require 'utils.php';
 
 		( function () {
 			$transformer = new Transformer( $this->storage_post_type );

--- a/src/plugin/class-schema.php
+++ b/src/plugin/class-schema.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+class Schema {
+	private static ?array $schema = null;
+
+	private static function load_schema(): void {
+		if ( null === self::$schema ) {
+			$schema_path  = plugin_dir_path( __FILE__ ) . 'schema.json';
+			self::$schema = wp_json_file_decode( $schema_path, array( 'associative' => true ) );
+
+			if ( json_last_error() !== JSON_ERROR_NONE ) {
+				wp_die( esc_html( 'Failed to parse schema.json - ' . json_last_error_msg() ) );
+			}
+		}
+	}
+
+	public static function get( $subject_type ): ?array {
+		self::load_schema();
+		if ( $subject_type ) {
+			return self::$schema[ $subject_type ] ?? null;
+		}
+		return self::$schema;
+	}
+}

--- a/src/plugin/class-schema.php
+++ b/src/plugin/class-schema.php
@@ -16,7 +16,7 @@ class Schema {
 		}
 	}
 
-	public static function get( $subject_type ): ?array {
+	public static function get( $subject_type = null ): ?array {
 		self::load_schema();
 		if ( $subject_type ) {
 			return self::$schema[ $subject_type ] ?? null;

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -75,7 +75,7 @@ class Subjects_Controller extends WP_REST_Controller {
 			foreach ( $definition['fields'] as $field => $field_definition ) {
 				$this->schema[ $subject_type ]['properties'][ 'raw' . ucfirst( $field ) ]    = array(
 					'description' => '[raw]' . $field_definition['description'] ?? '',
-					'type'        => $this->convert_schema_type_to_rest_api_type( $field_definition['type'] ),
+					'type'        => convert_schema_type_to_rest_api_type( $field_definition['type'] ),
 					'required'    => false,
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
@@ -83,7 +83,7 @@ class Subjects_Controller extends WP_REST_Controller {
 				);
 				$this->schema[ $subject_type ]['properties'][ 'parsed' . ucfirst( $field ) ] = array(
 					'description' => '[parsed]' . $field_definition['description'] ?? '',
-					'type'        => $this->convert_schema_type_to_rest_api_type( $field_definition['type'] ),
+					'type'        => convert_schema_type_to_rest_api_type( $field_definition['type'] ),
 					'required'    => false,
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
@@ -458,23 +458,5 @@ class Subjects_Controller extends WP_REST_Controller {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Function to convert type values specified by schema to one that's compatible with REST API
-	 *
-	 * REST API only accepts the following as type:
-	 * 'array', 'object', 'string', 'number', 'integer', 'boolean', null
-	 *
-	 * And in our schema, we have types like 'html', 'text'
-	 *
-	 * @param string $type Type from our schema.
-	 * @return string Type that REST API accepts
-	 */
-	private function convert_schema_type_to_rest_api_type( string $type ): string {
-		return match ( $type ) {
-			'html', 'text', 'date' => 'string',
-			default => $type,
-		};
 	}
 }

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -23,132 +23,31 @@ class Subjects_Controller extends WP_REST_Controller {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 
 		$this->attach_filters();
-		$this->get_item_schema();
 	}
 
 	public function init_schema(): void {
-		$this->schema = array(
-			'blog-post' => array(
+		$this->schema = array();
+		$new_schema   = Schema::get();
+
+		foreach ( $new_schema as $subject_type => $definition ) {
+			$this->schema[ $subject_type ] = array(
 				'$schema'    => 'http://json-schema.org/draft-04/schema#',
-				'title'      => 'blogpost',
-				'type'       => 'object',
-				'properties' => array(
-					'id'            => array(
-						'description' => __( 'Unique identifier for liberated blogpost', 'try_wordpress' ),
-						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
-					),
-					'authorId'      => array(
-						'description' => __( 'Author ID of the blogpost', 'try_wordpress' ),
-						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-					),
-					'sourceUrl'     => array(
-						'description' => __( 'Source URL from where the blogpost was liberated', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => true,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'sourceHtml'    => array(
-						'description' => __( 'Source HTML from where the blogpost was liberated', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawTitle'      => array(
-						'description' => __( 'Raw title of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedTitle'   => array(
-						'description' => __( 'Parsed title of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawDate'       => array(
-						'description' => __( 'Raw date of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedDate'    => array(
-						'description' => __( 'Parsed date of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawContent'    => array(
-						'description' => __( 'Raw content of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedContent' => array(
-						'description' => __( 'Parsed content of the blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'transformedId' => array(
-						'description' => __( 'Post ID of transformed result of this liberated blogpost', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-			),
-			'page'      => array(
-				'$schema'    => 'http://json-schema.org/draft-04/schema#',
-				'title'      => 'page',
+				'title'      => $definition['title'],
 				'type'       => 'object',
 				'properties' => array(
 					'id'            => array(
 						'description' => __( 'Unique identifier for liberated page', 'try_wordpress' ),
 						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),
 					'authorId'      => array(
 						'description' => __( 'Author ID of the page', 'try_wordpress' ),
 						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
 						'required'    => false,
 					),
 					'sourceUrl'     => array(
 						'description' => __( 'Source URL from where the page was liberated', 'try_wordpress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
 						'required'    => true,
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
@@ -157,61 +56,6 @@ class Subjects_Controller extends WP_REST_Controller {
 					'sourceHtml'    => array(
 						'description' => __( 'Source HTML from where the page was liberated', 'try_wordpress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawTitle'      => array(
-						'description' => __( 'Raw title of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedTitle'   => array(
-						'description' => __( 'Parsed title of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawDate'       => array(
-						'description' => __( 'Raw date of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedDate'    => array(
-						'description' => __( 'Parsed date of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'rawContent'    => array(
-						'description' => __( 'Raw content of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'required'    => false,
-						'arg_options' => array(
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-					'parsedContent' => array(
-						'description' => __( 'Parsed content of the page', 'try_wordpress' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
 						'required'    => false,
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
@@ -220,15 +64,33 @@ class Subjects_Controller extends WP_REST_Controller {
 					'transformedId' => array(
 						'description' => __( 'Post ID of transformed result of this liberated page', 'try_wordpress' ),
 						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
 						'required'    => false,
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
-			),
-		);
+			);
+
+			foreach ( $definition['fields'] as $field => $field_definition ) {
+				$this->schema[ $subject_type ]['properties'][ 'raw' . ucfirst( $field ) ]    = array(
+					'description' => '[raw]' . $field_definition['description'] ?? '',
+					'type'        => $this->convert_schema_type_to_rest_api_type( $field_definition['type'] ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				);
+				$this->schema[ $subject_type ]['properties'][ 'parsed' . ucfirst( $field ) ] = array(
+					'description' => '[parsed]' . $field_definition['description'] ?? '',
+					'type'        => $this->convert_schema_type_to_rest_api_type( $field_definition['type'] ),
+					'required'    => false,
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				);
+			}
+		}
 	}
 
 	public function register_routes(): void {
@@ -596,5 +458,23 @@ class Subjects_Controller extends WP_REST_Controller {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Function to convert type values specified by schema to one that's compatible with REST API
+	 *
+	 * REST API only accepts the following as type:
+	 * 'array', 'object', 'string', 'number', 'integer', 'boolean', null
+	 *
+	 * And in our schema, we have types like 'html', 'text'
+	 *
+	 * @param string $type Type from our schema.
+	 * @return string Type that REST API accepts
+	 */
+	private function convert_schema_type_to_rest_api_type( string $type ): string {
+		return match ( $type ) {
+			'html', 'text', 'date' => 'string',
+			default => $type,
+		};
 	}
 }

--- a/src/plugin/utils.php
+++ b/src/plugin/utils.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+/**
+ * Function to convert type values specified by schema to one that's compatible with REST API
+ *
+ * REST API only accepts the following as type:
+ * 'array', 'object', 'string', 'number', 'integer', 'boolean', null
+ *
+ * And in our schema, we have types like 'html', 'text'
+ *
+ * @param string $type Type from our schema.
+ * @return string Type that REST API accepts
+ */
+function convert_schema_type_to_rest_api_type( string $type ): string {
+	return match ( $type ) {
+		'html', 'text', 'date' => 'string',
+		default => $type,
+	};
+}

--- a/tests/plugin/test-utils.php
+++ b/tests/plugin/test-utils.php
@@ -1,0 +1,50 @@
+<?php
+
+use function DotOrg\TryWordPress\convert_schema_type_to_rest_api_type;
+
+class Test_Utils extends \WP_UnitTestCase {
+	/**
+	 * Tests the conversion of schema types to REST API types.
+	 *
+	 * @dataProvider data_convert_schema_type_to_rest_api_type
+	 * @param string $input    The input schema type to convert.
+	 * @param string $expected The expected REST API type.
+	 */
+	public function test_convert_schema_type_to_rest_api_type( string $input, string $expected ) {
+		$this->assertEquals( $expected, convert_schema_type_to_rest_api_type( $input ) );
+	}
+
+	/**
+	 * Data provider for test_convert_schema_type_to_rest_api_type.
+	 *
+	 * @return array[] Test cases with input and expected output.
+	 */
+	public function data_convert_schema_type_to_rest_api_type(): array {
+		return array(
+			'html type converts to string'   => array(
+				'html',
+				'string',
+			),
+			'text type converts to string'   => array(
+				'text',
+				'string',
+			),
+			'date type converts to string'   => array(
+				'date',
+				'string',
+			),
+			'number type remains unchanged'  => array(
+				'number',
+				'number',
+			),
+			'boolean type remains unchanged' => array(
+				'boolean',
+				'boolean',
+			),
+			'integer type remains unchanged' => array(
+				'integer',
+				'integer',
+			),
+		);
+	}
+}


### PR DESCRIPTION
This PR transforms our schema to what REST API accepts, effectively turning our schema driving the API endpoints.

We didn't need to add any fields to our schema. All specific fields for a subject type, are available as flattened object fields only. Effectively all fields are `required => false` as brought up in #162 

closes #164 #136 #138 #152