### PR TITLE
Ensure transformedId is an int

### DIFF
--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -63,8 +63,9 @@ class Subjects_Controller extends WP_REST_Controller {
 					),
 					'transformedId' => array(
 						'description' => __( 'Post ID of transformed result of this liberated page', 'try_wordpress' ),
-						'type'        => 'string',
+						'type'        => 'integer',
 						'required'    => false,
+						'readonly'    => true,
 						'arg_options' => array(
 							'sanitize_callback' => 'sanitize_text_field',
 						),
@@ -378,7 +379,7 @@ class Subjects_Controller extends WP_REST_Controller {
 			'parsedDate'    => $item['post_date'] ?? '',
 			'rawContent'    => get_post_meta( $item['ID'], 'raw_content', true ),
 			'parsedContent' => $item['post_content'] ?? '',
-			'transformedId' => get_post_meta( $item['ID'], '_dl_transformed', true ),
+			'transformedId' => absint( get_post_meta( $item['ID'], '_dl_transformed', true ) ),
 		);
 
 		$response['previewUrl'] = get_permalink( $response['transformedId'] );

--- a/tests/plugin/test-blogpost-controller.php
+++ b/tests/plugin/test-blogpost-controller.php
@@ -143,6 +143,11 @@ class Blogpost_Controller_Test extends TestCase {
 		$this->assertEquals( $this->parsed_content, $post->post_content );
 		$this->assertEquals( $author_id, $post->post_author );
 		$this->assertEquals( $this->parsed_date, $post->post_date );
+
+		// assert types
+		$this->assertIsInt( $response_data['id'] );
+		$this->assertIsInt( $response_data['authorId'] );
+		$this->assertIsInt( $response_data['transformedId'] );
 	}
 
 	public function testCreateItemMissingSourceUrl() {


### PR DESCRIPTION
This ensures `transformedId` is an int & not a string containing an int value. Also made it readonly for REST API context since frontend will never update its value. Lastly, added tests to ensure types show up correctly for int values.