### PR TITLE
Correctly call API when searching by source URL

### DIFF
--- a/src/api/SubjectsApi.ts
+++ b/src/api/SubjectsApi.ts
@@ -38,7 +38,9 @@ export class SubjectsApi {
 		type: SubjectType,
 		sourceUrl: string
 	): Promise< Subject | null > {
-		const path = `${ getEndpoint( type ) }&sourceurl=${ sourceUrl }`;
+		const path = `${ getEndpoint( type ) }&sourceurl=${ encodeURIComponent(
+			sourceUrl
+		) }`;
 		const post = ( await this.client.get( path ) ) as ApiPost;
 		return post ? fromApiResponse( type, post ) : null;
 	}

--- a/src/api/SubjectsApi.ts
+++ b/src/api/SubjectsApi.ts
@@ -38,7 +38,7 @@ export class SubjectsApi {
 		type: SubjectType,
 		sourceUrl: string
 	): Promise< Subject | null > {
-		const path = `${ getEndpoint( type ) }?sourceurl=${ sourceUrl }`;
+		const path = `${ getEndpoint( type ) }&sourceurl=${ sourceUrl }`;
 		const post = ( await this.client.get( path ) ) as ApiPost;
 		return post ? fromApiResponse( type, post ) : null;
 	}

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -336,6 +336,7 @@ class Subjects_Controller extends WP_REST_Controller {
 
 	public function search_item( $request ): WP_Error|WP_REST_Response {
 		$guid = $request['sourceurl'] ?? '';
+		$guid = urldecode( $guid );
 
 		if ( empty( $guid ) ) {
 			return new WP_Error(


### PR DESCRIPTION
Fixes #172 

The API was been called incorrectly. I also took the liberty of URL-encoding the field, otherwise it could break the URL parsing, for example if `sourceurl` would be `http://foo?bar=baz`, because this would result in the following URL:

> Note there are two `?`

```
/wp-json/index.php?rest_route=/try-wp/v1/subjects/blog-post&sourceurl=http://foo?bar=baz
```