### PR TITLE
Log playground requests

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -3,9 +3,10 @@ import { SettingsApi } from '@/api/Settings';
 import { UsersApi } from '@/api/Users';
 import { BlueprintsApi } from '@/api/Blueprints';
 import { SubjectsApi } from '@/api/SubjectsApi';
+import { PlaygroundHttpProxy } from '@/ui/preview/PlaygroundHttpProxy';
 
 export class ApiClient {
-	private readonly playgroundClient: PlaygroundClient;
+	private readonly _client: PlaygroundHttpProxy;
 	private readonly _siteUrl: string;
 	private readonly _subjects: SubjectsApi;
 	private readonly _settings: SettingsApi;
@@ -13,7 +14,7 @@ export class ApiClient {
 	private readonly _blueprints: BlueprintsApi;
 
 	constructor( playgroundClient: PlaygroundClient, siteUrl: string ) {
-		this.playgroundClient = playgroundClient;
+		this._client = new PlaygroundHttpProxy( playgroundClient );
 		this._siteUrl = siteUrl;
 		this._blueprints = new BlueprintsApi( this );
 		this._subjects = new SubjectsApi( this );
@@ -50,7 +51,7 @@ export class ApiClient {
 			const encoded = encodeURIComponent( params[ name ] );
 			url += `&${ name }=${ encoded }`;
 		}
-		const response = await this.playgroundClient.request( {
+		const response = await this._client.request( {
 			url,
 			method: 'GET',
 		} );
@@ -66,7 +67,7 @@ export class ApiClient {
 
 	async post( route: string, body: object ): Promise< object > {
 		const url = `/index.php?rest_route=/try-wp/v1${ route }`;
-		const response = await this.playgroundClient.request( {
+		const response = await this._client.request( {
 			url,
 			method: 'POST',
 			headers: {

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -1,4 +1,4 @@
-import { PHPResponse, PlaygroundClient } from '@wp-playground/client';
+import { PlaygroundClient } from '@wp-playground/client';
 import { SettingsApi } from '@/api/Settings';
 import { UsersApi } from '@/api/Users';
 import { BlueprintsApi } from '@/api/Blueprints';
@@ -59,7 +59,6 @@ export class ApiClient {
 			return null;
 		}
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
-			logFailedRequest( { url, params, response } );
 			throw Error( response.json.message );
 		}
 		return response.json;
@@ -77,23 +76,8 @@ export class ApiClient {
 		} );
 
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
-			logFailedRequest( { url, response } );
 			throw Error( response.json.message );
 		}
 		return response.json;
-	}
-}
-
-function logFailedRequest( args: {
-	url: string;
-	params?: Record< string, string >;
-	response: PHPResponse;
-} ) {
-	const { url, params, response } = args;
-	const message = `Request to ${ url } failed [${ response.httpStatusCode }]`;
-	if ( params ) {
-		console.error( message, params, response.json, response );
-	} else {
-		console.error( message, response.json, response );
 	}
 }

--- a/src/ui/preview/PlaygroundHttpProxy.ts
+++ b/src/ui/preview/PlaygroundHttpProxy.ts
@@ -1,0 +1,9 @@
+import { PHPRequest, PlaygroundClient } from '@wp-playground/client';
+
+export class PlaygroundHttpProxy {
+	constructor( private readonly client: PlaygroundClient ) {}
+
+	async request( request: PHPRequest ) {
+		return await this.client.request( request );
+	}
+}

--- a/src/ui/preview/PlaygroundHttpProxy.ts
+++ b/src/ui/preview/PlaygroundHttpProxy.ts
@@ -12,7 +12,7 @@ export class PlaygroundHttpProxy {
 
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
 			logFailedRequest( { request, response } );
-		} else if ( process.env.OPFS_ENABLED === 'true' ) {
+		} else if ( process.env.LOG_REQUESTS === 'true' ) {
 			logRequest( { request, response } );
 		}
 
@@ -23,13 +23,10 @@ export class PlaygroundHttpProxy {
 function logRequest( args: { request: PHPRequest; response: PHPResponse } ) {
 	const { request, response } = args;
 	const url = request.url;
-	const params = request.body;
-	const message = `[Request] ${ url } [${ response.httpStatusCode }]`;
-	if ( params ) {
-		console.log( message, params, response.json, response );
-	} else {
-		console.log( message, response.json, response );
-	}
+	const message = `[Request] ${ url }
+[Request body] ${ request.body }
+[Response] (${ response.httpStatusCode })`;
+	console.log( message, response.json );
 }
 
 function logFailedRequest( args: {

--- a/src/ui/preview/PlaygroundHttpProxy.ts
+++ b/src/ui/preview/PlaygroundHttpProxy.ts
@@ -1,9 +1,34 @@
-import { PHPRequest, PlaygroundClient } from '@wp-playground/client';
+import {
+	PHPRequest,
+	PHPResponse,
+	PlaygroundClient,
+} from '@wp-playground/client';
 
 export class PlaygroundHttpProxy {
 	constructor( private readonly client: PlaygroundClient ) {}
 
-	async request( request: PHPRequest ) {
-		return await this.client.request( request );
+	async request( request: PHPRequest ): Promise< PHPResponse > {
+		const response = await this.client.request( request );
+
+		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
+			logFailedRequest( { request, response } );
+		}
+
+		return response;
+	}
+}
+
+function logFailedRequest( args: {
+	request: PHPRequest;
+	response: PHPResponse;
+} ) {
+	const { request, response } = args;
+	const url = request.url;
+	const params = request.body;
+	const message = `Request to ${ url } failed [${ response.httpStatusCode }]`;
+	if ( params ) {
+		console.error( message, params, response.json, response );
+	} else {
+		console.error( message, response.json, response );
 	}
 }

--- a/src/ui/preview/PlaygroundHttpProxy.ts
+++ b/src/ui/preview/PlaygroundHttpProxy.ts
@@ -23,10 +23,23 @@ export class PlaygroundHttpProxy {
 function logRequest( args: { request: PHPRequest; response: PHPResponse } ) {
 	const { request, response } = args;
 	const url = request.url;
-	const message = `[Request] ${ url }
-[Request body] ${ request.body }
-[Response] (${ response.httpStatusCode })`;
-	console.log( message, response.json );
+	console.log( {
+		type: 'API Request/Response',
+		request: {
+			url,
+			body:
+				typeof request.body === 'string'
+					? ( () => {
+							try {
+								return JSON.parse( request.body );
+							} catch {
+								return request.body;
+							}
+					  } )()
+					: request.body,
+		},
+		response: { status: response.httpStatusCode, body: response.json },
+	} );
 }
 
 function logFailedRequest( args: {

--- a/src/ui/preview/PlaygroundHttpProxy.ts
+++ b/src/ui/preview/PlaygroundHttpProxy.ts
@@ -12,9 +12,23 @@ export class PlaygroundHttpProxy {
 
 		if ( response.httpStatusCode < 200 || response.httpStatusCode >= 300 ) {
 			logFailedRequest( { request, response } );
+		} else if ( process.env.OPFS_ENABLED === 'true' ) {
+			logRequest( { request, response } );
 		}
 
 		return response;
+	}
+}
+
+function logRequest( args: { request: PHPRequest; response: PHPResponse } ) {
+	const { request, response } = args;
+	const url = request.url;
+	const params = request.body;
+	const message = `[Request] ${ url } [${ response.httpStatusCode }]`;
+	if ( params ) {
+		console.log( message, params, response.json, response );
+	} else {
+		console.log( message, response.json, response );
 	}
 }
 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -90,6 +90,9 @@ function extensionModules( mode, target ) {
 		'process.env.OPFS_ENABLED': JSON.stringify(
 			mode === 'production' ? 'true' : 'false'
 		),
+		'process.env.LOG_REQUESTS': JSON.stringify(
+			mode === 'development' ? 'true' : 'false'
+		),
 	} );
 
 	return [


### PR DESCRIPTION
This PR logs all requests to playground in the browser console, when in development environments:

<img width="909" alt="Screenshot 2024-12-19 at 16 48 46" src="https://github.com/user-attachments/assets/9fe8ed34-a5b1-4a50-abe8-9ec3e3e16517" />

Ideally we would want the requests to show in the network tab of browser tools, which I think would be possible with a service worker (which would serve as proxy between the extension and playground), but getting that working would not be a quick fix, so I figured I wouldn't do that just yet.
