### PR TITLE
Define custom hooks for transformer when liberated data is ready for transformation

### DIFF
--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -15,7 +15,7 @@ class Engine {
 		require 'utils.php';
 
 		( function () {
-			$transformer = new Transformer( $this->storage_post_type );
+			$transformer = new Transformer();
 
 			new Post_Type_UI( $this->storage_post_type, $transformer );
 

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -292,6 +292,8 @@ class Subjects_Controller extends WP_REST_Controller {
 		$subject_type = $this->get_subject_type( $request );
 		update_post_meta( $item['ID'], 'subject_type', $subject_type );
 
+		do_action( 'dl_data_saved', $item['ID'], 'create' );
+
 		return $this->prepare_item_for_response( $item, $request, $subject_type );
 	}
 
@@ -313,6 +315,8 @@ class Subjects_Controller extends WP_REST_Controller {
 		foreach ( $item_meta as $key => $value ) {
 			update_post_meta( $item['ID'], $key, $value );
 		}
+
+		do_action( 'dl_data_saved', $item['ID'], 'update' );
 
 		return $this->prepare_item_for_response( $item, $request );
 	}

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -7,15 +7,8 @@ use WP_Post;
 class Transformer {
 	private string $meta_key_for_transformed_post = '_dl_transformed';
 
-	public function __construct( $post_type ) {
-		add_action(
-			'save_post_' . $post_type,
-			function ( $post_id, $post ) {
-				$this->transform( $post );
-			},
-			10,
-			2
-		);
+	public function __construct() {
+		add_action( 'dl_data_saved', array( $this, 'transform' ), 10, 2 );
 	}
 
 	private function get_post_type_for_transformed_post( int|WP_Post $liberated_post ): string {
@@ -51,14 +44,12 @@ class Transformer {
 		return absint( $value );
 	}
 
-	public function transform( int|WP_Post $liberated_post ): bool {
+	public function transform( int $liberated_post_id, string $verb ): bool {
 		if ( apply_filters( 'skip_native_transformation', false ) ) {
 			return true;
 		}
 
-		if ( is_int( $liberated_post ) ) {
-			$liberated_post = get_post( $liberated_post );
-		}
+		$liberated_post = get_post( $liberated_post_id );
 
 		$transformed_post_id = get_post_meta( $liberated_post->ID, $this->meta_key_for_transformed_post, true );
 

--- a/tests/plugin/test-transformer.php
+++ b/tests/plugin/test-transformer.php
@@ -60,7 +60,7 @@ class Transformer_Test extends TestCase {
 	}
 
 	public function testTransform(): void {
-		$result = $this->transformer->transform( get_post( $this->post_id_in_db ) );
+		$result = $this->transformer->transform( $this->post_id_in_db, 'whatever' ); // verb isn't currently used
 
 		$transformed_post_id = absint( get_post_meta( $this->post_id_in_db, '_dl_transformed', true ) );
 


### PR DESCRIPTION
This PR fixes the issue in #182 

@psrpinto identified the issue that transformations run right after post is saved since we were using save_post hook and that happens before post meta were saved.

So now we define custom hooks for transformations that we ourselves invoke for transformations to run.

Currently there is another issue, that's preventing it from successfully testing it, but if you swap out playground instance from `playground.wordpress.net` to `pg.ashfame.com` then it works.