### PR TITLE
Guarantee that src/plugin/schema.json is up-to-date

### DIFF
--- a/.github/workflows/wp-tests.yml
+++ b/.github/workflows/wp-tests.yml
@@ -48,7 +48,7 @@ jobs:
                     composer-options: "--no-progress --no-ansi --no-interaction"
 
             -   name: Build schema.json
-                run: npm install && npm run build:schema && cp schema/schema.json src/plugin/
+                run: npm install && npm run build:schema
 
             -   name: Install WordPress test setup
                 run: bash tests/bin/install-wp-tests.sh wordpress_test root password 127.0.0.1:${{ job.services.mysql.ports[3306] }} latest

--- a/schema/build.mjs
+++ b/schema/build.mjs
@@ -8,7 +8,7 @@
 import { Ajv } from 'ajv';
 import { fileURLToPath } from 'url';
 import * as path from 'node:path';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, readFileSync } from 'node:fs';
 import * as fs from 'node:fs';
 
 const cwd = path.dirname( fileURLToPath( import.meta.url ) );
@@ -62,6 +62,11 @@ for ( const schema of schemas ) {
 fs.writeFileSync(
 	outputSchemaPath,
 	JSON.stringify( outputSchema, null, '\t' )
+);
+
+copyFileSync(
+	outputSchemaPath,
+	path.join( cwd, '..', 'src', 'plugin', 'schema.json' )
 );
 
 console.log( 'Schema file generated successfully:', outputSchemaPath );

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,4 +1,3 @@
-const { copyFileSync } = require( 'node:fs' );
 const path = require( 'node:path' );
 const { execSync } = require( 'child_process' );
 const CopyPlugin = require( 'copy-webpack-plugin' );

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -215,7 +215,6 @@ class EmitSubjectsSchemaPlugin {
 					},
 					async ( assets, callback ) => {
 						execSync( './schema/build.mjs', { stdio: 'inherit' } );
-						copyFileSync( SCHEMA_SRC, SCHEMA_PLUGIN_PATH );
 						callback();
 					}
 				);


### PR DESCRIPTION
It should not be possible for `src/plugin/schema.json` to be different than `schema/schema.json`. By having the build script of the schema place the file under `src/plugin`, we guarantee this.