### PR TITLE
DevEx API

### DIFF
--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -9,7 +9,7 @@ class Engine {
 	public function __construct() {
 		require 'enum-subject-type.php';
 
-		require 'class-transformersregistry.php';
+		require 'class-transformers-registry.php';
 		require 'class-post-type-ui.php';
 		require 'class-transformer.php';
 		require 'class-subjects-controller.php';

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -17,6 +17,7 @@ class Engine {
 		require 'class-schema.php';
 		require 'utils.php';
 		require 'class-subject.php';
+		require 'class-ops.php';
 
 		( function () {
 			new Transformer();
@@ -26,6 +27,8 @@ class Engine {
 			new Subjects_Controller( self::STORAGE_POST_TYPE );
 
 			new Storage( self::STORAGE_POST_TYPE );
+
+			Ops::init( self::STORAGE_POST_TYPE );
 		} )();
 	}
 }

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -9,7 +9,7 @@ class Engine {
 	public function __construct() {
 		require 'enum-subject-type.php';
 
-		require 'class-transformers-registry.php';
+		require 'class-handlers-registry.php';
 		require 'class-post-type-ui.php';
 		require 'class-transformer.php';
 		require 'class-subjects-controller.php';

--- a/src/plugin/class-engine.php
+++ b/src/plugin/class-engine.php
@@ -8,16 +8,21 @@ class Engine {
 
 	public function __construct() {
 		require 'enum-subject-type.php';
+		require 'class-subject.php';
+		require 'class-schema.php';
 
 		require 'class-handlers-registry.php';
+		require 'class-observers-registry.php';
+
+		require 'class-subjects-controller.php';
+
+		require 'class-storage.php';
+
 		require 'class-post-type-ui.php';
 		require 'class-transformer.php';
-		require 'class-subjects-controller.php';
-		require 'class-storage.php';
-		require 'class-schema.php';
-		require 'utils.php';
-		require 'class-subject.php';
 		require 'class-ops.php';
+
+		require 'utils.php';
 
 		( function () {
 			new Transformer();

--- a/src/plugin/class-handlers-registry.php
+++ b/src/plugin/class-handlers-registry.php
@@ -91,18 +91,6 @@ class Handlers_Registry {
 	}
 
 	/**
-	 * Remove all handlers for a type
-	 *
-	 * @param SubjectType $type The type to clear handlers for.
-	 * @return void
-	 */
-	public static function clear( SubjectType $type ): void {
-		if ( isset( self::$handlers[ $type->value ] ) ) {
-			unset( self::$handlers[ $type->value ] );
-		}
-	}
-
-	/**
 	 * Set user choice for what transformer to run for a subject type when multiples are registered
 	 *
 	 * @param SubjectType $type The subject type for which choice is to be saved.

--- a/src/plugin/class-handlers-registry.php
+++ b/src/plugin/class-handlers-registry.php
@@ -5,7 +5,7 @@ namespace DotOrg\TryWordPress;
 use Exception;
 use InvalidArgumentException;
 
-class Transformers_Registry {
+class Handlers_Registry {
 	private static string $user_choice_meta_key_prefix = '_data_liberation_chosen_handler_';
 	private static array $handlers                     = array();
 

--- a/src/plugin/class-observers-registry.php
+++ b/src/plugin/class-observers-registry.php
@@ -62,16 +62,4 @@ class Observers_Registry {
 			$registered_observer['observer']( $subject );
 		}
 	}
-
-	/**
-	 * Remove all observers for a type
-	 *
-	 * @param SubjectType $type The type to clear observers for.
-	 * @return void
-	 */
-	public static function clear( SubjectType $type ): void {
-		if ( isset( self::$observers[ $type->value ] ) ) {
-			unset( self::$observers[ $type->value ] );
-		}
-	}
 }

--- a/src/plugin/class-observers-registry.php
+++ b/src/plugin/class-observers-registry.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use Exception;
+use InvalidArgumentException;
+
+class Observers_Registry {
+	private static array $observers = array();
+
+	/**
+	 * Add a observer for a specific subject type
+	 *
+	 * @param SubjectType $type The subject type for which observer should be registered.
+	 * @param array       $identifier Array containing unique slug and description.
+	 * @param callable    $observer The observer function.
+	 * @return void
+	 * @throws InvalidArgumentException If observer is not callable.
+	 */
+	public static function add( SubjectType $type, array $identifier, callable $observer ): void {
+		if ( ! is_callable( $observer ) ) {
+			throw new InvalidArgumentException( 'observer must be callable' );
+		}
+
+		if ( ! isset( $identifier['slug'] ) ) {
+			throw new InvalidArgumentException( 'Identifier slug must be defined' );
+		}
+
+		if ( ! isset( self::$observers[ $type->value ] ) ) {
+			self::$observers[ $type->value ] = array();
+		}
+
+		self::$observers[ $type->value ][ $identifier['slug'] ] = array(
+			'slug'        => $identifier['slug'],
+			'description' => $identifier['description'],
+			'observer'    => $observer,
+		);
+	}
+
+	/**
+	 * Check if observers exist for a type
+	 *
+	 * @param SubjectType $type The subject type to check for.
+	 * @return bool True if observers exist
+	 */
+	public static function has( SubjectType $type ): bool {
+		return isset( self::$observers[ $type->value ] ) && ! empty( self::$observers[ $type->value ] );
+	}
+
+	/**
+	 * Execute all observers for a type
+	 *
+	 * @param SubjectType $type The subject type to handle.
+	 * @param Subject     $subject Data to pass to observers.
+	 * @return void
+	 */
+	public static function observe( SubjectType $type, Subject $subject ): void {
+		if ( ! self::has( $type ) ) {
+			return;
+		}
+		foreach ( self::$observers[ $type->value ] as $registered_observer ) {
+			$registered_observer['observer']( $subject );
+		}
+	}
+
+	/**
+	 * Remove all observers for a type
+	 *
+	 * @param SubjectType $type The type to clear observers for.
+	 * @return void
+	 */
+	public static function clear( SubjectType $type ): void {
+		if ( isset( self::$observers[ $type->value ] ) ) {
+			unset( self::$observers[ $type->value ] );
+		}
+	}
+}

--- a/src/plugin/class-ops.php
+++ b/src/plugin/class-ops.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DotOrg\TryWordPress;
+
+use WP_Post;
+
+class Ops {
+	private static string $post_type;
+
+	public static function init( string $post_type ): void {
+		static::$post_type = $post_type;
+	}
+
+	/**
+	 * Register your handler for the specified subject type
+	 *
+	 * @param SubjectType $subject_type Type of subject.
+	 * @param array       $identifier Array containing unique slug and description.
+	 * @param callable    $handler Function that would handle the transformation of subject for the specific subject type.
+	 * @return void
+	 */
+	public static function handle( SubjectType $subject_type, array $identifier, callable $handler ): void {
+		Handlers_Registry::add( $subject_type, $identifier, $handler );
+	}
+
+	/**
+	 * Register your handler for the specified subject type to just observe (read-only) data
+	 *
+	 * @param SubjectType $subject_type Type of subject.
+	 * @param array       $identifier Array containing unique slug and description.
+	 * @param callable    $handler Function that would handle the transformation of subject for the specific subject type.
+	 * @return void
+	 */
+	public static function observe( SubjectType $subject_type, array $identifier, callable $handler ): void {
+		Observers_Registry::add( $subject_type, $identifier, $handler );
+	}
+
+	/**
+	 * Loops over all liberated_post posts for the specified subject_type
+	 *
+	 * @TODO: pagination support
+	 *
+	 * @param SubjectType $subject_type Type of subject.
+	 * @return Subject[]
+	 */
+	public static function loop( SubjectType $subject_type ): array {
+		$args  = array(
+			'post_type'      => static::$post_type,
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			// @phpcs:ignore
+			'meta_query'     => array(
+				'key'     => 'subject_type',
+				'value'   => $subject_type->value,
+				'compare' => '=',
+			),
+		);
+		$posts = get_posts( $args );
+
+		return array_map(
+			fn( WP_Post $post ) => Subject::from_post( $post->ID ),
+			$posts
+		);
+	}
+}

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -292,7 +292,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		update_post_meta( $item['ID'], 'subject_type', $subject_type->value );
 
 		try {
-			TransformersRegistry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			Transformers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
@@ -322,7 +322,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		$subject_type = $this->get_subject_type( $request );
 
 		try {
-			TransformersRegistry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			Transformers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -292,7 +292,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		update_post_meta( $item['ID'], 'subject_type', $subject_type->value );
 
 		try {
-			Transformers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			Handlers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
@@ -322,7 +322,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		$subject_type = $this->get_subject_type( $request );
 
 		try {
-			Transformers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			Handlers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}

--- a/src/plugin/class-subjects-controller.php
+++ b/src/plugin/class-subjects-controller.php
@@ -292,7 +292,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		update_post_meta( $item['ID'], 'subject_type', $subject_type->value );
 
 		try {
-			Handlers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			$this->announce_subject( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
@@ -322,7 +322,7 @@ class Subjects_Controller extends WP_REST_Controller {
 		$subject_type = $this->get_subject_type( $request );
 
 		try {
-			Handlers_Registry::handle( $subject_type, Subject::from_post( $item['ID'] ) );
+			$this->announce_subject( $subject_type, Subject::from_post( $item['ID'] ) );
 		} catch ( Exception $e ) {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
@@ -464,5 +464,17 @@ class Subjects_Controller extends WP_REST_Controller {
 	private function get_subject_type( $request ): SubjectType {
 		preg_match( '/\/subjects\/([^\/]+)/', $request->get_route(), $matches );
 		return SubjectType::tryFrom( $matches[1] );
+	}
+
+	/**
+	 * Announce subject to Observers_Registry & Handlers_Registry
+	 *
+	 * @param SubjectType $subject_type Type of subject to announce.
+	 * @param Subject     $subject Subject instance to announce.
+	 * @throws Exception Handlers_Registry::handle can throw an exception.
+	 */
+	private function announce_subject( SubjectType $subject_type, Subject $subject ): void {
+		Observers_Registry::observe( $subject_type, $subject );
+		Handlers_Registry::handle( $subject_type, $subject );
 	}
 }

--- a/src/plugin/class-transformer.php
+++ b/src/plugin/class-transformer.php
@@ -7,7 +7,7 @@ class Transformer {
 	public const string META_KEY_LIBERATED_OUTPUT = '_data_liberation_output';
 
 	public function __construct() {
-		TransformersRegistry::add(
+		Ops::handle(
 			SubjectType::BLOGPOST,
 			array(
 				'slug'        => 'try_wordpress',
@@ -19,7 +19,7 @@ class Transformer {
 			)
 		);
 
-		TransformersRegistry::add(
+		Ops::handle(
 			SubjectType::PAGE,
 			array(
 				'slug'        => 'try_wordpress',

--- a/src/plugin/class-transformers-registry.php
+++ b/src/plugin/class-transformers-registry.php
@@ -5,7 +5,7 @@ namespace DotOrg\TryWordPress;
 use Exception;
 use InvalidArgumentException;
 
-class TransformersRegistry {
+class Transformers_Registry {
 	private static string $user_choice_meta_key_prefix = '_data_liberation_chosen_handler_';
 	private static array $handlers                     = array();
 


### PR DESCRIPTION
Closes #193 

Requires #191 to be merged first.

This PR introduces `Ops` class, the only class developers would need to interact with. Everything else is abstracted away for them.

Under Ops class, we manage Handlers registry (earlier built as Transformers registry) and Observers registry, to handle or observe subjects as they are liberated.